### PR TITLE
feat(Dialog): Dialog 컴포넌트 추가

### DIFF
--- a/packages/my-components/package.json
+++ b/packages/my-components/package.json
@@ -32,6 +32,7 @@
         "react-dom": "^18.3.1"
     },
     "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1",
         "classnames": "^2.5.1"
     }
 }

--- a/packages/my-components/src/Dialog/Dialog.module.scss
+++ b/packages/my-components/src/Dialog/Dialog.module.scss
@@ -5,18 +5,25 @@
     gap: 0; // var(--Spacing-space-000, 0px);
 
     position: fixed;
-    top: 50%;
+    top: 0;
     left: 50%;
-    transform: translate(-50%, -50%);
+    transform: translate(-50%, 1.75rem);
 
     width: 100%;
-
     border-radius: 8px;
 
     background-color: #fff;
     box-shadow: 0px 16px 32px 0px rgba(0, 0, 0, 0.2); // Light/Box-shadow/$box-shadow-xl
 
-    animation: contentShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
+    opacity: 0;
+
+    &[data-state='open'] {
+        animation: contentShow 300ms 150ms ease-out forwards;
+    }
+
+    &[data-state='closed'] {
+        animation: contentHide 300ms ease-out forwards;
+    }
 
     &_md {
         max-width: 500px;
@@ -47,30 +54,51 @@
     height: 100vh;
     background: var(--basic-color-base-black-transparent-32, #00000052);
 
-    inset: 0;
-    animation: overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
+    &[data-state='open'] {
+        animation: fadeIn 150ms linear;
+    }
 
-    &_preventClose {
-        pointer-events: none;
+    &[data-state='closed'] {
+        animation: fadeOut 150ms linear;
     }
 }
 
-@keyframes overlayShow {
+@keyframes fadeIn {
     from {
         opacity: 0;
     }
     to {
         opacity: 1;
+    }
+}
+
+@keyframes fadeOut {
+    from {
+        opacity: 1;
+    }
+    to {
+        opacity: 0;
     }
 }
 
 @keyframes contentShow {
     from {
         opacity: 0;
-        transform: translate(-50%, -48%) scale(0.96);
+        transform: translate(-50%, calc(1.75rem - 50px));
     }
     to {
         opacity: 1;
-        transform: translate(-50%, -50%) scale(1);
+        transform: translate(-50%, 1.75rem);
+    }
+}
+
+@keyframes contentHide {
+    from {
+        opacity: 1;
+        transform: translate(-50%, 1.75rem);
+    }
+    to {
+        opacity: 0;
+        transform: translate(-50%, calc(1.75rem - 50px));
     }
 }

--- a/packages/my-components/src/Dialog/Dialog.module.scss
+++ b/packages/my-components/src/Dialog/Dialog.module.scss
@@ -1,3 +1,76 @@
-.dialog {
-    background-color: antiquewhite;
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0; // var(--Spacing-space-000, 0px);
+
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+
+    width: 100%;
+
+    border-radius: 8px;
+
+    background-color: #fff;
+    box-shadow: 0px 16px 32px 0px rgba(0, 0, 0, 0.2); // Light/Box-shadow/$box-shadow-xl
+
+    animation: contentShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
+
+    &_md {
+        max-width: 500px;
+    }
+
+    &_lg {
+        max-width: 800px;
+    }
+
+    &_xl {
+        max-width: 1140px;
+    }
+
+    &:focus {
+        outline: none;
+    }
+
+    > * {
+        box-sizing: border-box;
+    }
+}
+
+.scrim {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: var(--basic-color-base-black-transparent-32, #00000052);
+
+    inset: 0;
+    animation: overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
+
+    &_preventClose {
+        pointer-events: none;
+    }
+}
+
+@keyframes overlayShow {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes contentShow {
+    from {
+        opacity: 0;
+        transform: translate(-50%, -48%) scale(0.96);
+    }
+    to {
+        opacity: 1;
+        transform: translate(-50%, -50%) scale(1);
+    }
 }

--- a/packages/my-components/src/Dialog/Dialog.tsx
+++ b/packages/my-components/src/Dialog/Dialog.tsx
@@ -1,10 +1,50 @@
-import React from 'react';
+import {
+    Dialog as RadixDialog,
+    Portal as RadixPortal,
+    Content as RadixContent,
+    Overlay as RadixScrim,
+} from '@radix-ui/react-dialog';
 import cn from 'classnames';
+import React from 'react';
 
+import DialogContent from './DialogContent/DialogContent';
+import DialogFooter from './DialogFooter/DialogFooter';
+import DialogHeader from './DialogHeader/DialogHeader';
+
+import { DialogProps } from './Dialog.types';
 import styles from './Dialog.module.scss';
 
-const Dialog = () => {
-    return <div className={cn(styles.dialog)}>ddd</div>;
+const Dialog = ({
+    size = 'md',
+    preventScrimBehavior = false,
+    open,
+    onOpenChange,
+    children,
+    ...props
+}: DialogProps) => {
+    const dialogSizeStyle = styles[`wrapper_${size}`];
+    const handleScrimBehavior = (e: Event) => {
+        if (preventScrimBehavior) e.preventDefault();
+    };
+
+    return (
+        <RadixDialog open={open} onOpenChange={onOpenChange} {...props}>
+            <RadixPortal>
+                <RadixScrim className={styles.scrim} />
+                <RadixContent
+                    className={cn(styles.wrapper, dialogSizeStyle)}
+                    onPointerDownOutside={handleScrimBehavior}
+                    aria-describedby="hi"
+                >
+                    {children}
+                </RadixContent>
+            </RadixPortal>
+        </RadixDialog>
+    );
 };
+
+Dialog.Header = DialogHeader;
+Dialog.Content = DialogContent;
+Dialog.Footer = DialogFooter;
 
 export default Dialog;

--- a/packages/my-components/src/Dialog/Dialog.types.ts
+++ b/packages/my-components/src/Dialog/Dialog.types.ts
@@ -1,0 +1,17 @@
+import { DialogProps as RadixDialogProps } from '@radix-ui/react-dialog';
+import { PropsWithChildren } from 'react';
+
+type SizeToken = 'md' | 'lg' | 'xl';
+
+export type DialogContextType = {
+    size: SizeToken;
+    preventScrimBehavior?: boolean;
+};
+
+export type DialogProps = MakeRequired<
+    DialogContextType & RadixDialogProps,
+    'children'
+>;
+
+export type MakeRequired<T, U extends keyof T> = T & { [P in U]-?: T[P] };
+export type WithChildren = MakeRequired<PropsWithChildren, 'children'>;

--- a/packages/my-components/src/Dialog/DialogContent/DialogContent.module.scss
+++ b/packages/my-components/src/Dialog/DialogContent/DialogContent.module.scss
@@ -1,0 +1,8 @@
+.content {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    width: 100%;
+    padding: 16px 24px 24px 24px;
+}

--- a/packages/my-components/src/Dialog/DialogContent/DialogContent.tsx
+++ b/packages/my-components/src/Dialog/DialogContent/DialogContent.tsx
@@ -1,0 +1,29 @@
+import React, { Children, forwardRef, isValidElement, ReactNode } from 'react';
+import cn from 'classnames';
+
+import styles from './DialogContent.module.scss';
+import { DialogContentProps } from './DialogContent.types';
+
+const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(
+    ({ className, children, ...props }, ref) => {
+        const slotCount = Children.count(children);
+        let elements: ReactNode | null = children;
+
+        if (slotCount > 5) {
+            console.warn('Dialog can have 5 slots');
+
+            elements = Children.toArray(children)
+                .filter((child) => isValidElement(child))
+                .slice(0, 5);
+        }
+
+        return (
+            <div ref={ref} className={cn(styles.content, className)} {...props}>
+                {elements}
+            </div>
+        );
+    },
+);
+DialogContent.displayName = 'DialogContent';
+
+export default DialogContent;

--- a/packages/my-components/src/Dialog/DialogContent/DialogContent.types.ts
+++ b/packages/my-components/src/Dialog/DialogContent/DialogContent.types.ts
@@ -1,0 +1,3 @@
+import { ComponentProps } from 'react';
+
+export type DialogContentProps = ComponentProps<'div'>;

--- a/packages/my-components/src/Dialog/DialogContent/index.ts
+++ b/packages/my-components/src/Dialog/DialogContent/index.ts
@@ -1,0 +1,3 @@
+import DialogContent from './DialogContent';
+
+export default DialogContent;

--- a/packages/my-components/src/Dialog/DialogFooter/DialogFooter.module.scss
+++ b/packages/my-components/src/Dialog/DialogFooter/DialogFooter.module.scss
@@ -1,0 +1,19 @@
+.footer {
+    display: flex;
+    flex-direction: row-reverse;
+    align-items: center;
+    gap: 8px;
+
+    width: 100%;
+
+    padding: 16px 24px;
+    border: solid var(--semantic-color-border-border-color, #e1e1e8); // semantic color/border/border-color
+    border-width: 1px 0 0 0;
+
+    &_stacked {
+        flex-direction: column;
+        align-items: stretch;
+
+        border: 0;
+    }
+}

--- a/packages/my-components/src/Dialog/DialogFooter/DialogFooter.tsx
+++ b/packages/my-components/src/Dialog/DialogFooter/DialogFooter.tsx
@@ -1,0 +1,20 @@
+import React, { forwardRef } from 'react';
+import cn from 'classnames';
+
+import styles from './DialogFooter.module.scss';
+import { DialogFooterProps } from './DialogFooter.types';
+
+const DialogFooter = forwardRef<HTMLDivElement, DialogFooterProps>(
+    ({ type = 'default', children }, ref) => {
+        const footerTypeStyle = styles[`footer_${type}`];
+
+        return (
+            <div ref={ref} className={cn(styles.footer, footerTypeStyle)}>
+                {children}
+            </div>
+        );
+    },
+);
+DialogFooter.displayName = 'DialogFooter';
+
+export default DialogFooter;

--- a/packages/my-components/src/Dialog/DialogFooter/DialogFooter.types.ts
+++ b/packages/my-components/src/Dialog/DialogFooter/DialogFooter.types.ts
@@ -1,5 +1,5 @@
-import { PropsWithChildren } from 'react';
+import { WithChildren } from '../Dialog.types';
 
-export type DialogFooterProps = PropsWithChildren<{
+export type DialogFooterProps = WithChildren & {
     type?: 'default' | 'stacked';
-}>;
+};

--- a/packages/my-components/src/Dialog/DialogFooter/DialogFooter.types.ts
+++ b/packages/my-components/src/Dialog/DialogFooter/DialogFooter.types.ts
@@ -1,0 +1,5 @@
+import { PropsWithChildren } from 'react';
+
+export type DialogFooterProps = PropsWithChildren<{
+    type?: 'default' | 'stacked';
+}>;

--- a/packages/my-components/src/Dialog/DialogFooter/index.ts
+++ b/packages/my-components/src/Dialog/DialogFooter/index.ts
@@ -1,0 +1,3 @@
+import DialogFooter from './DialogFooter';
+
+export default DialogFooter;

--- a/packages/my-components/src/Dialog/DialogHeader/DialogHeader.module.scss
+++ b/packages/my-components/src/Dialog/DialogHeader/DialogHeader.module.scss
@@ -1,0 +1,39 @@
+.header {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: var(--Spacing-space-150, 12px); // space-150: 12px, .75rem
+    flex-shrink: 0;
+
+    width: 100%;
+    height: var(--dimension-700, 56px); // --demension-700: 56px
+    padding: 15px var(--Spacing-space-300, 24px); // space-300: 24px, 1.5rem
+
+    &_title {
+        margin: 0;
+
+        color: var(--semantic-color-text-text-normal, #2b2d36);
+        font-feature-settings: 'clig' off, 'liga' off;
+
+        font-size: 18px;
+        font-style: normal;
+        font-weight: 700;
+        line-height: 26px; /* 144.444% */
+        letter-spacing: -0.1px;
+    }
+
+    &_close {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 0;
+        border: 0;
+        outline: 0;
+        background-color: transparent;
+        cursor: pointer;
+
+        &:focus {
+            box-shadow: 0 0 2px 2px blanchedalmond;
+        }
+    }
+}

--- a/packages/my-components/src/Dialog/DialogHeader/DialogHeader.tsx
+++ b/packages/my-components/src/Dialog/DialogHeader/DialogHeader.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { DialogHeaderProps } from './DialogHeader.types';
+import styles from './DialogHeader.module.scss';
+import IconBase from '../../Icon/IconBase';
+import { DialogClose, DialogTitle } from '@radix-ui/react-dialog';
+
+const CloseIcon = () => {
+    return (
+        <IconBase
+            fill="#6C6E7E" // semantic color/theme/hint
+            width="20"
+            height="20"
+            viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M12.459 4.4595L8.91902 8.0005L12.459 11.5405L11.541 12.4595L8.00002 8.9185L4.45902 12.4595L3.54102 11.5405L7.08102 8.0005L3.54102 4.4595L4.45902 3.5405L8.00002 7.0815L11.541 3.5405L12.459 4.4595Z"
+            />
+        </IconBase>
+    );
+};
+
+const DialogHeader = ({ showClose = true, children }: DialogHeaderProps) => {
+    return (
+        <div className={styles.header}>
+            <DialogTitle className={styles[`header_title`]}>
+                {children}
+            </DialogTitle>
+            {showClose && (
+                <DialogClose className={styles[`header_close`]}>
+                    <CloseIcon />
+                </DialogClose>
+            )}
+        </div>
+    );
+};
+
+export default DialogHeader;

--- a/packages/my-components/src/Dialog/DialogHeader/DialogHeader.types.ts
+++ b/packages/my-components/src/Dialog/DialogHeader/DialogHeader.types.ts
@@ -1,0 +1,5 @@
+import { PropsWithChildren } from 'react';
+
+export type DialogHeaderProps = PropsWithChildren<{
+    showClose: boolean;
+}>;

--- a/packages/my-components/src/Dialog/DialogHeader/index.ts
+++ b/packages/my-components/src/Dialog/DialogHeader/index.ts
@@ -1,0 +1,3 @@
+import DialogHeader from './DialogHeader';
+
+export default DialogHeader;


### PR DESCRIPTION
> 아래 섹션들은 모두 선택사항입니다. 필요에 따라, 작성하지 않은 섹션은 지워주세요.

## 📝 변경 사항 요약
> 간략하게 변경 사항을 요약해주세요.

- Dialog 컴포넌트를 추가했습니다.


## 🛠 변경 사항 상세 설명
> 변경 사항을 상세히 설명해주세요. 왜 이러한 변경이 필요했는지, 어떻게 구현되었는지에 대해 적어주세요.
- 디자인 시안에 의거하여 크게 Dialog, DialogHeader, DialogContent, DialogFooter 컴포넌트로 나뉩니다.
- Dialog 컴포넌트는 모든 컴포넌트를 감싸는 상위 컴포넌트이며, Controlled 하게 구현되어 있습니다.
  - 사용자는 open, onOpenChange props를 전달하여 다이얼로그 on/off 상태를 컨트롤 할 수 있습니다.
  - preventScrimBehavior props를 통해 Scrim(다이얼로그 영역 밖)을 클릭 시 컴포넌트의 on/off 동작을 제어할 수 있습니다.
- Header 컴포넌트는 제목을 포함하는 컴포넌트입니다.
  - 접근성을 위해 Radix-ui/react-dialog는 DialogTitle을 필수로 사용할 것을 권고하고 있기 때문에 현재는 DialogHeader 컴포넌트에 포함시켜 두었습니다.
  - 하지만 디자인 시안에 따라 Dialog의 type이 icon인 경우 Title이 Content 내부에 오는 경우도 있기 때문에, 이를 위해 DialogHeader와 DialogTitle을 분리하는 것에 대해 고민하고 있습니다.
  - 이렇게 할 시, 조합형 컴포넌트 패키지(Vapor-Components)에서 type에 따라 DialogTitle의 위치를 사전에 결정하고 사용자에게 텍스트만 입력받도록 하는 방법을 통해 제어할 수 있을 것 같습니다.
- Content 컴포넌트는 최대 5개까지의 슬롯을 가질 수 있습니다.
  - 따라서 React.Children() API를 이용하여 슬롯이 5개 이상인 경우 console.warn()을 띄워주고 Array.slice() 메서드로 처음부터 5개까지 잘라줬습니다.
- Footer 컴포넌트는 버튼을 전달 받을 수 있습니다.
  - type props를 이용하여 버튼의 배치 정도를 제어할 수 있습니다.
