### PR TITLE
fix(my-components): classnames를 clsx로 교체

### DIFF
--- a/packages/my-components/package.json
+++ b/packages/my-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@noahnoahchoi/my-components",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/types/index.d.ts",
@@ -33,6 +33,6 @@
     },
     "dependencies": {
         "@radix-ui/react-dialog": "^1.1.1",
-        "classnames": "^2.5.1"
+        "clsx": "^2.1.1"
     }
 }

--- a/packages/my-components/src/Button/Button.tsx
+++ b/packages/my-components/src/Button/Button.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentProps } from 'react';
 
 import styles from './Button.module.scss';
-import cn from 'classnames';
+import { clsx } from 'clsx';
 
 type ButtonProps = {
     variant?: 'primary' | 'link';
@@ -10,7 +10,10 @@ type ButtonProps = {
 const Button = ({ variant = 'primary', ...props }: ButtonProps) => {
     const buttonVariantStyle = styles[`button_${variant}`];
     return (
-        <button className={cn(styles.button, buttonVariantStyle)} {...props} />
+        <button
+            className={clsx(styles.button, buttonVariantStyle)}
+            {...props}
+        />
     );
 };
 

--- a/packages/my-components/src/Dialog/Dialog.tsx
+++ b/packages/my-components/src/Dialog/Dialog.tsx
@@ -4,7 +4,7 @@ import {
     Content as RadixContent,
     Overlay as RadixScrim,
 } from '@radix-ui/react-dialog';
-import cn from 'classnames';
+import { clsx } from 'clsx';
 import React from 'react';
 
 import DialogContent from './DialogContent/DialogContent';
@@ -32,7 +32,7 @@ const Dialog = ({
             <RadixPortal>
                 <RadixScrim className={styles.scrim} />
                 <RadixContent
-                    className={cn(styles.wrapper, dialogSizeStyle)}
+                    className={clsx(styles.wrapper, dialogSizeStyle)}
                     onPointerDownOutside={handleScrimBehavior}
                     aria-describedby="hi"
                 >

--- a/packages/my-components/src/Dialog/DialogContent/DialogContent.tsx
+++ b/packages/my-components/src/Dialog/DialogContent/DialogContent.tsx
@@ -1,5 +1,5 @@
 import React, { Children, forwardRef, isValidElement, ReactNode } from 'react';
-import cn from 'classnames';
+import { clsx } from 'clsx';
 
 import styles from './DialogContent.module.scss';
 import { DialogContentProps } from './DialogContent.types';
@@ -18,7 +18,11 @@ const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(
         }
 
         return (
-            <div ref={ref} className={cn(styles.content, className)} {...props}>
+            <div
+                ref={ref}
+                className={clsx(styles.content, className)}
+                {...props}
+            >
                 {elements}
             </div>
         );

--- a/packages/my-components/src/Dialog/DialogFooter/DialogFooter.tsx
+++ b/packages/my-components/src/Dialog/DialogFooter/DialogFooter.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import cn from 'classnames';
+import { clsx } from 'clsx';
 
 import styles from './DialogFooter.module.scss';
 import { DialogFooterProps } from './DialogFooter.types';
@@ -9,7 +9,7 @@ const DialogFooter = forwardRef<HTMLDivElement, DialogFooterProps>(
         const footerTypeStyle = styles[`footer_${type}`];
 
         return (
-            <div ref={ref} className={cn(styles.footer, footerTypeStyle)}>
+            <div ref={ref} className={clsx(styles.footer, footerTypeStyle)}>
                 {children}
             </div>
         );


### PR DESCRIPTION
> 아래 섹션들은 모두 선택사항입니다. 필요에 따라, 작성하지 않은 섹션은 지워주세요.

## 📝 변경 사항 요약
> 간략하게 변경 사항을 요약해주세요.

- my-components 패키지의 classnames를 clsx로 교체


## 🛠 변경 사항 상세 설명
- rollup을 이용하여 build 할 때, classnames 라이브러리 내부에 default export 키워드가 존재하지 않아 에러가 발생합니다.
- [classnames의 이슈](https://github.com/JedWatson/classnames/issues/357)에서도 같은 문제를 다루고 있고, 아직까지 해결되지는 않은 것처럼 보입니다.
- 따라서 패키지 용량도 절감할 겸 clsx로 라이브러리를 교체했습니다.