### PR TITLE
feat(storybook): Dialog Storybook docs 생성

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
     "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "npmClient": "yarn",
     "packages": ["packages/*"]
 }

--- a/packages/my-components/package.json
+++ b/packages/my-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@noahnoahchoi/my-components",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/types/index.d.ts",

--- a/packages/my-components/src/Dialog/Dialog.tsx
+++ b/packages/my-components/src/Dialog/Dialog.tsx
@@ -7,9 +7,9 @@ import {
 import { clsx } from 'clsx';
 import React from 'react';
 
-import DialogContent from './DialogContent/DialogContent';
-import DialogFooter from './DialogFooter/DialogFooter';
-import DialogHeader from './DialogHeader/DialogHeader';
+import DialogContent from './DialogContent';
+import DialogFooter from './DialogFooter';
+import DialogHeader from './DialogHeader';
 
 import { DialogProps } from './Dialog.types';
 import styles from './Dialog.module.scss';

--- a/packages/my-components/src/Dialog/DialogHeader/DialogHeader.tsx
+++ b/packages/my-components/src/Dialog/DialogHeader/DialogHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { DialogHeaderProps } from './DialogHeader.types';
 import styles from './DialogHeader.module.scss';
@@ -23,19 +23,24 @@ const CloseIcon = () => {
     );
 };
 
-const DialogHeader = ({ showClose = true, children }: DialogHeaderProps) => {
-    return (
-        <div className={styles.header}>
-            <DialogTitle className={styles[`header_title`]}>
-                {children}
-            </DialogTitle>
-            {showClose && (
-                <DialogClose className={styles[`header_close`]}>
-                    <CloseIcon />
-                </DialogClose>
-            )}
-        </div>
-    );
-};
+const DialogHeader = forwardRef<HTMLDivElement, DialogHeaderProps>(
+    ({ showClose = true, children }, ref) => {
+        return (
+            <div ref={ref} className={styles.header}>
+                <DialogTitle className={styles[`header_title`]}>
+                    {children}
+                </DialogTitle>
+
+                {showClose && (
+                    <DialogClose className={styles[`header_close`]}>
+                        <CloseIcon />
+                    </DialogClose>
+                )}
+            </div>
+        );
+    },
+);
+
+DialogHeader.displayName = 'DialogHeader';
 
 export default DialogHeader;

--- a/packages/my-docs/package.json
+++ b/packages/my-docs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@noahnoahchoi/my-docs",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "license": "ISC",
     "author": "noahnoahchoi",
     "scripts": {
@@ -25,6 +25,6 @@
         "vite": "^5.3.3"
     },
     "dependencies": {
-        "@noahnoahchoi/my-components": "^0.1.3"
+        "@noahnoahchoi/my-components": "^0.1.4"
     }
 }

--- a/packages/my-docs/stories/Dialog.stories.tsx
+++ b/packages/my-docs/stories/Dialog.stories.tsx
@@ -6,6 +6,7 @@ import { Button, Dialog } from '@noahnoahchoi/my-components';
 const meta: Meta<typeof Dialog> = {
     title: 'Dialog',
     component: Dialog,
+    tags: ['autodocs'],
     parameters: {
         docs: {
             description: {


### PR DESCRIPTION
> 아래 섹션들은 모두 선택사항입니다. 필요에 따라, 작성하지 않은 섹션은 지워주세요.

## 📝 변경 사항 요약
> 간략하게 변경 사항을 요약해주세요.

- Dialog Storybook docs 생성


## 🛠 변경 사항 상세 설명
- Dialog 스토리에 docs를 추가합니다.
- Dialog Header 최상위 컴포넌트인 div 태그에 ref 를 전달합니다.
- docs에 컴포넌트 명을 올바르게 표시하기 위해 Display Name을 지정합니다.