### PR TITLE
feat(NoBody): NoBody 컴포넌트 추가

### DIFF
--- a/packages/my-components/index.ts
+++ b/packages/my-components/index.ts
@@ -1,3 +1,4 @@
 export { default as Dialog } from './src/Dialog';
 export { default as Button } from './src/Button';
-// export { default as Calendar } from './src/Calendar';
+export { default as Calendar } from './src/Calendar';
+export { default as NoBody } from './src/NoBody';

--- a/packages/my-components/package.json
+++ b/packages/my-components/package.json
@@ -33,6 +33,7 @@
     },
     "dependencies": {
         "@radix-ui/react-dialog": "^1.1.1",
+        "@radix-ui/react-popover": "^1.1.1",
         "clsx": "^2.1.1",
         "react-calendar": "^5.0.0"
     }

--- a/packages/my-components/src/NoBody/NoBody.tsx
+++ b/packages/my-components/src/NoBody/NoBody.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import * as PopoverPrimitives from '@radix-ui/react-popover';
+
+const NoBodyContent = React.forwardRef<
+    React.ElementRef<typeof PopoverPrimitives.Content>,
+    React.ComponentPropsWithoutRef<typeof PopoverPrimitives.Content>
+>(({ children, ...props }, ref) => {
+    return (
+        <PopoverPrimitives.Portal>
+            <PopoverPrimitives.Content ref={ref} {...props}>
+                {children}
+            </PopoverPrimitives.Content>
+        </PopoverPrimitives.Portal>
+    );
+});
+NoBodyContent.displayName = 'NoBodyContent';
+
+export default Object.assign(PopoverPrimitives.Root, PopoverPrimitives, {
+    Content: NoBodyContent,
+});

--- a/packages/my-components/src/NoBody/index.ts
+++ b/packages/my-components/src/NoBody/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NoBody';

--- a/packages/my-docs/stories/NoBody.stories.tsx
+++ b/packages/my-docs/stories/NoBody.stories.tsx
@@ -1,0 +1,48 @@
+import { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import NoBody from '@noahnoahchoi/my-components/src/NoBody';
+
+const meta: Meta<typeof NoBody> = {
+    title: 'NoBody',
+    component: NoBody,
+    parameters: {
+        layout: 'centered',
+    },
+    args: {
+        modal: false,
+    },
+    argTypes: {
+        modal: { control: 'boolean' },
+    },
+    tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof NoBody>;
+
+export const Modal: Story = {
+    render: (args) => {
+        return (
+            <div style={{ height: '1000vh' }}>
+                <NoBody modal={args.modal}>
+                    <NoBody.Trigger>d</NoBody.Trigger>
+                    <NoBody.Content
+                        side="bottom"
+                        align="start"
+                        sideOffset={5}
+                        style={{
+                            width: '100px',
+                            height: '100px',
+                            backgroundColor: 'lightgrey',
+                        }}
+                    >
+                        <div>{args.modal ? '스크롤 안됨' : '스크롤 됨'}</div>
+                    </NoBody.Content>
+                </NoBody>
+
+                <div id="bcbcbc"></div>
+            </div>
+        );
+    },
+};

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,7 +33,7 @@ function buildJS(input, output, format) {
     };
 
     const externals = () => {
-        const defaultExternal = [/@babel\/runtime/];
+        const defaultExternal = [];
         const dependencies = Object.keys(pkg?.dependencies || {});
         const peerDependencies = Object.keys(pkg?.peerDependencies || {});
 
@@ -45,15 +45,13 @@ function buildJS(input, output, format) {
     const plugins = [
         // 바벨 설정
         babel({
-            babelHelpers: 'runtime', // 바벨 헬퍼 함수를 번들 결과에 포함하지 않음
-            exclude: 'node_modules/**',
+            babelHelpers: 'bundled', // runtime: 바벨 헬퍼 함수를 번들 결과에 포함하지 않음 / bundled: 번들 결과에 포함함
             extensions,
             presets: [
                 '@babel/preset-env', // es6 compile
                 '@babel/preset-react', // react compile
                 '@babel/preset-typescript', // typescript compile
             ],
-            plugins: ['@babel/plugin-transform-runtime'],
         }),
         commonjs({ extensions }), // commonjs 코드를 es6로 변환
         nodeResolve({ extensions }), // 라이브러리에서 외부 의존성 사용하도록, 트리 셰이킹도 가능하게


### PR DESCRIPTION
> 아래 섹션들은 모두 선택사항입니다. 필요에 따라, 작성하지 않은 섹션은 지워주세요.

## 📝 변경 사항 요약
> 간략하게 변경 사항을 요약해주세요.

- `@radix-ui/react-popover`를 래핑한 NoBody 컴포넌트 추가


## 🛠 변경 사항 상세 설명
- Popover 형식의 컴포넌트를 일관성 있게 관리하기 위해 NoBody 컴포넌트를 생성했습니다.
- root의 modal(boolean) props에 따라 팝오버 되었을 때 스크롤 차단 여부를 결정합니다.
- 이에 맞게 스토리북을 작성했습니다.
- rollup 빌드 시 외부 의존성을 적절하게 빌드하지 못하는 에러가 발생하여 babelHelpers: `bundled`로 수정하여 일시적으로 해결했습니다.
  - 빌드 시 `Error: 'default' is not exported by` 에러가 여기저기서 터져 나왔고, commonjs로 작성된 외부 의존성을 esm으로 변환하지 못하는 문제라 판단하여 commonjs 플러그인을 사용해보아도 해결하지 못했습니다.
  - 해결이 된 이유는 외부 의존성이 빌드될 때 이에 필요한 바벨 함수들이 번들에 포함되기 때문에 에러를 해결할 수 있었던 것으로 보입니다.