### PR TITLE
feat(DatePicker): 데이트 피커 컴포넌트 추가

### DIFF
--- a/packages/my-components/index.ts
+++ b/packages/my-components/index.ts
@@ -2,3 +2,4 @@ export { default as Dialog } from './src/Dialog';
 export { default as Button } from './src/Button';
 export { default as Calendar } from './src/Calendar';
 export { default as NoBody } from './src/NoBody';
+export { default as DatePicker } from './src/DatePicker';

--- a/packages/my-components/src/DatePicker/DatePicker.constants.ts
+++ b/packages/my-components/src/DatePicker/DatePicker.constants.ts
@@ -1,0 +1,5 @@
+export const LOCALES = {
+    ko: 'ko-KR',
+    ja: 'ja-JP',
+    en: 'en-US',
+} as const;

--- a/packages/my-components/src/DatePicker/DatePicker.context.tsx
+++ b/packages/my-components/src/DatePicker/DatePicker.context.tsx
@@ -1,0 +1,75 @@
+import React, { useContext, useState, createContext, useEffect } from 'react';
+
+import {
+    DatePickerContextType,
+    DatePickerDate,
+    DatePickerProviderProps,
+    InitializeRangeProps,
+} from './DatePicker.types';
+
+// Context
+const DatePickerContext = createContext<DatePickerContextType>({
+    date: null,
+    defaultDate: null,
+    handleChange: () => {},
+    mode: 'single',
+    locale: 'ko',
+    initializeRange: () => {},
+    minDate: undefined,
+    maxDate: undefined,
+});
+
+const DatePickerProvider = ({
+    date,
+    onChangeDate,
+    mode = 'single',
+    locale = 'ko',
+    children,
+}: DatePickerProviderProps) => {
+    const [defaultDate, setDefaultDate] = useState<DatePickerDate | null>(null);
+    const [range, setRange] = useState<InitializeRangeProps>({
+        minDate: new Date('1970.01.01'),
+        maxDate: new Date('2999.12.31'),
+    });
+
+    const handleChange = (date: DatePickerDate) => {
+        //! mode range는 일단 무시
+        onChangeDate?.(date);
+    };
+
+    const initializeRange = ({ minDate, maxDate }: InitializeRangeProps) => {
+        if (minDate) setRange((p) => ({ ...p, minDate }));
+        if (maxDate) setRange((p) => ({ ...p, maxDate }));
+    };
+
+    useEffect(() => {
+        setDefaultDate(date);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return (
+        <DatePickerContext.Provider
+            value={{
+                ...range,
+                date,
+                defaultDate,
+                initializeRange,
+                handleChange,
+                mode,
+                locale,
+            }}
+        >
+            {children}
+        </DatePickerContext.Provider>
+    );
+};
+
+export default DatePickerProvider;
+
+export const useDatePicker = () => {
+    const context = useContext(DatePickerContext);
+
+    if (!context) throw new Error('can not find DatePickerContext');
+
+    return context;
+};

--- a/packages/my-components/src/DatePicker/DatePicker.tsx
+++ b/packages/my-components/src/DatePicker/DatePicker.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import NoBody from '../NoBody';
+import DatePickerProvider from './DatePicker.context';
+import DatePickerCalendar from './DatePickerCalendar';
+import DatePickerFooter from './DatePickerFooter';
+import DatePickerHeader from './DatePickerHeader';
+import DatePickerReset from './DatePickerReset/DatePickerReset';
+import DatePickerTrigger from './DatePickerTrigger';
+import DatePickerInput from './DatePickerInput';
+
+import { DatePickerProps } from './DatePicker.types';
+import DatePickerContent from './DatePickerContent';
+
+const DatePicker = ({
+    // NoBody props
+    open,
+    onOpenChange,
+    defaultOpen,
+    modal,
+
+    // DatePickerProvider Props
+    children,
+    ...props
+}: DatePickerProps) => {
+    return (
+        <NoBody
+            open={open}
+            onOpenChange={onOpenChange}
+            defaultOpen={defaultOpen}
+            modal={modal}
+        >
+            <DatePickerProvider {...props}>{children}</DatePickerProvider>
+        </NoBody>
+    );
+};
+
+DatePicker.Trigger = DatePickerTrigger;
+DatePicker.Calendar = DatePickerCalendar;
+DatePicker.Header = DatePickerHeader;
+DatePicker.Content = DatePickerContent;
+DatePicker.Footer = DatePickerFooter;
+DatePicker.Reset = DatePickerReset;
+DatePicker.Input = DatePickerInput;
+
+export default DatePicker;

--- a/packages/my-components/src/DatePicker/DatePicker.types.ts
+++ b/packages/my-components/src/DatePicker/DatePicker.types.ts
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react';
+
+export type Locale = 'ko' | 'ja' | 'en';
+export type Mode = 'single' | 'range';
+
+export type DatePickerDate = Date | [Date, Date] | null;
+
+export type InitializeRangeProps = {
+    minDate: Date | undefined;
+    maxDate: Date | undefined;
+};
+
+export type DatePickerContextType = {
+    date: DatePickerDate;
+    defaultDate: DatePickerDate;
+    handleChange: (date: DatePickerDate) => void;
+    initializeRange: (range: InitializeRangeProps) => void;
+    mode?: Mode;
+    locale: Locale;
+} & InitializeRangeProps;
+
+export type DatePickerProviderProps = {
+    mode?: Mode;
+    locale?: Locale;
+    date: DatePickerDate;
+    onChangeDate: (date: DatePickerDate) => void;
+    children: ReactNode;
+};

--- a/packages/my-components/src/DatePicker/DatePicker.types.ts
+++ b/packages/my-components/src/DatePicker/DatePicker.types.ts
@@ -1,4 +1,5 @@
-import { ReactNode } from 'react';
+import { ComponentProps, ReactNode } from 'react';
+import NoBody from '../NoBody';
 
 export type Locale = 'ko' | 'ja' | 'en';
 export type Mode = 'single' | 'range';
@@ -26,3 +27,6 @@ export type DatePickerProviderProps = {
     onChangeDate: (date: DatePickerDate) => void;
     children: ReactNode;
 };
+
+export type DatePickerProps = DatePickerProviderProps &
+    ComponentProps<typeof NoBody>;

--- a/packages/my-components/src/DatePicker/DatePicker.utils.ts
+++ b/packages/my-components/src/DatePicker/DatePicker.utils.ts
@@ -1,0 +1,62 @@
+import { InitializeRangeProps, Locale } from './DatePicker.types';
+
+// *** 한자리수 월/일 -> 0 채워주기
+const datePads = (value: number) => {
+    return `${value}`.padStart(2, '0');
+};
+
+// *** 날짜 formating
+export const dateFormat = (date: Date, locale: Locale) => {
+    if (!date) {
+        return null;
+    }
+    const formatDate = date;
+
+    const y = formatDate.getFullYear();
+    const m = datePads(formatDate.getMonth() + 1);
+    const d = datePads(formatDate.getDate());
+
+    if (locale === 'ko') return `${y}.${m}.${d}`;
+    return `${m}.${d}.${y}`;
+};
+
+type IsDateFormatProps = { y: string; m: string; d: string };
+export const isDateFormat = ({ y, m, d }: IsDateFormatProps) => {
+    const date = new Date(`${y}-${m}-${d}`);
+
+    if (!date.getTime()) return false;
+    else return true;
+};
+
+export const getYMD = (value: string, locale: Locale) => {
+    const dates = value.replace(/[./]/g, ' ').split(' ');
+    let y, m, d;
+
+    if (locale === 'ko') {
+        [y, m, d] = dates;
+    } else {
+        [m, d, y] = dates;
+    }
+
+    return { y, m, d };
+};
+
+export const isValidDate = (value: string, locale: Locale) => {
+    return isDateFormat(getYMD(value, locale));
+};
+
+type CheckRangeProps = {
+    value: string;
+} & InitializeRangeProps;
+export const constrainDateToRange = ({
+    value,
+    minDate,
+    maxDate,
+}: CheckRangeProps) => {
+    const date = new Date(value);
+
+    if (minDate && date < minDate) return minDate;
+    if (maxDate && date > maxDate) return maxDate;
+
+    return date;
+};

--- a/packages/my-components/src/DatePicker/DatePickerCalendar/DatePickerCalendar.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerCalendar/DatePickerCalendar.tsx
@@ -1,0 +1,31 @@
+import React, { ComponentProps, useEffect } from 'react';
+
+import Calendar from '../../Calendar';
+import { useDatePicker } from '../DatePicker.context';
+import { LooseValue } from 'react-calendar/dist/cjs/shared/types';
+
+const DatePickerCalendar = ({
+    maxDate,
+    minDate,
+    ...props
+}: ComponentProps<typeof Calendar>) => {
+    const { date, handleChange, locale, initializeRange } = useDatePicker();
+
+    useEffect(() => {
+        initializeRange({ maxDate, minDate });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return (
+        <Calendar
+            value={date as LooseValue}
+            onChange={(date) => handleChange(date as Date)}
+            locale={locale}
+            minDate={minDate}
+            maxDate={maxDate}
+            {...props}
+        />
+    );
+};
+
+export default DatePickerCalendar;

--- a/packages/my-components/src/DatePicker/DatePickerCalendar/index.ts
+++ b/packages/my-components/src/DatePicker/DatePickerCalendar/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DatePickerCalendar';

--- a/packages/my-components/src/DatePicker/DatePickerContent/DatePicker.module.scss
+++ b/packages/my-components/src/DatePicker/DatePickerContent/DatePicker.module.scss
@@ -1,0 +1,4 @@
+.content {
+    border: 0.0625rem solid var(--border-color, rgb(225, 225, 232));
+    border-radius: 0.5rem;
+}

--- a/packages/my-components/src/DatePicker/DatePickerContent/DatePickerContent.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerContent/DatePickerContent.tsx
@@ -1,0 +1,17 @@
+import React, { ComponentProps } from 'react';
+import NoBody from '../../NoBody';
+
+import styles from './DatePicker.module.scss';
+
+const DatePickerContent = ({
+    children,
+    ...props
+}: ComponentProps<typeof NoBody.Content>) => {
+    return (
+        <NoBody.Content {...props} className={styles.content}>
+            {children}
+        </NoBody.Content>
+    );
+};
+
+export default DatePickerContent;

--- a/packages/my-components/src/DatePicker/DatePickerContent/index.ts
+++ b/packages/my-components/src/DatePicker/DatePickerContent/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DatePickerContent';

--- a/packages/my-components/src/DatePicker/DatePickerFooter/DatePickerFooter.module.scss
+++ b/packages/my-components/src/DatePicker/DatePickerFooter/DatePickerFooter.module.scss
@@ -1,0 +1,9 @@
+.footer {
+    display: flex;
+    align-items: center;
+    padding: 1rem;
+    margin: 0;
+    border-top: 1px solid var(--border-color, rgb(225, 225, 232));
+    background-color: var(--background-normal, rgb(255, 255, 255));
+    border-radius: 0 0 0.5rem 0.5rem;
+}

--- a/packages/my-components/src/DatePicker/DatePickerFooter/DatePickerFooter.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerFooter/DatePickerFooter.tsx
@@ -1,0 +1,10 @@
+import React, { ComponentProps } from 'react';
+
+import styles from './DatePickerFooter.module.scss';
+import { clsx } from 'clsx';
+
+const DatePickerFooter = ({ className, ...props }: ComponentProps<'div'>) => {
+    return <div className={clsx(styles.footer, className)} {...props} />;
+};
+
+export default DatePickerFooter;

--- a/packages/my-components/src/DatePicker/DatePickerFooter/index.ts
+++ b/packages/my-components/src/DatePicker/DatePickerFooter/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DatePickerFooter';

--- a/packages/my-components/src/DatePicker/DatePickerHeader/DatePickerHeader.module.scss
+++ b/packages/my-components/src/DatePicker/DatePickerHeader/DatePickerHeader.module.scss
@@ -1,0 +1,7 @@
+.header {
+    display: flex;
+    border-bottom: 1px solid var(--border-color, rgb(225, 225, 232));
+    padding: 0.75rem 1rem;
+    background-color: var(--background-, rgb(255, 255, 255));
+    border-radius: 0.5rem 0.5rem 0 0;
+}

--- a/packages/my-components/src/DatePicker/DatePickerHeader/DatePickerHeader.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerHeader/DatePickerHeader.tsx
@@ -1,0 +1,10 @@
+import React, { ComponentProps } from 'react';
+
+import styles from './DatePickerHeader.module.scss';
+import { clsx } from 'clsx';
+
+const DatePickerHeader = ({ className, ...props }: ComponentProps<'div'>) => {
+    return <div className={clsx(styles.header, className)} {...props} />;
+};
+
+export default DatePickerHeader;

--- a/packages/my-components/src/DatePicker/DatePickerHeader/index.ts
+++ b/packages/my-components/src/DatePicker/DatePickerHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DatePickerHeader';

--- a/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.module.scss
+++ b/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.module.scss
@@ -1,0 +1,75 @@
+.input_trigger {
+    cursor: pointer;
+}
+
+.DatePickerField {
+    width: 100%;
+    position: relative;
+
+    &__calendarIcon {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        left: 0.75rem /* 12px -> .75rem */;
+    }
+    &__cancelIcon {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        right: 0.75rem /* 12px -> .75rem */;
+        cursor: pointer;
+    }
+
+    & + & {
+        margin-left: 0.5rem /* 8px -> .5rem */;
+    }
+
+    // reactstrap style
+    &__input {
+        box-sizing: border-box;
+        display: block;
+        width: 100%;
+        height: 2rem;
+        padding: 0.3125rem /* 5px -> .3125rem */ 0.75rem /* 12px -> .75rem */
+            0.3125rem /* 5px -> .3125rem */ 2.25rem /* 36px -> 2.25rem */;
+
+        font-size: 0.875rem;
+        font-weight: 400;
+        line-height: 1.375rem;
+        color: var(--text-normal, rgb(43, 45, 54));
+        background-color: var(--background-normal, rgb(255, 255, 255));
+        background-clip: padding-box;
+        border: 0.0625rem solid var(--border-color, rgb(225, 225, 232));
+        border-radius: 0.5rem;
+        transition:
+            border-color 0.25s ease,
+            box-shadow 0.25s ease;
+
+        &:not(&--invalid):hover {
+            border-color: var(--semantic-color-border-border-hover, #cdced6);
+            outline: 0;
+        }
+
+        &:not(&_trigger):not(&--invalid):focus-within {
+            border: 1px solid var(--primary, rgb(80, 148, 250));
+            outline: 0;
+        }
+
+        &--default {
+            padding: 0.3125rem /* 5px -> .3125rem */ 0.75rem
+                /* 12px -> .75rem */ 0.3125rem /* 5px -> .3125rem */ 2.25rem
+                /* 36px -> 2.25rem */;
+        }
+
+        &--valid {
+            padding: 0.3125rem /* 5px -> .3125rem */ 2.25rem
+                /* 36px -> 2.25rem */ 0.3125rem /* 5px -> .3125rem */ 0.75rem
+                /* 12px -> .75rem */;
+        }
+
+        &--invalid {
+            border: 1px solid var(--danger, rgb(245, 83, 94));
+            outline: 0;
+        }
+    }
+}

--- a/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.tsx
@@ -1,0 +1,199 @@
+import React, {
+    ChangeEvent,
+    ComponentProps,
+    FocusEvent,
+    KeyboardEvent,
+    useEffect,
+    useState,
+} from 'react';
+import { clsx } from 'clsx';
+
+import { useDatePicker } from '../DatePicker.context';
+import {
+    constrainDateToRange,
+    dateFormat,
+    isValidDate,
+} from '../DatePicker.utils';
+
+import styles from './DatePickerInput.module.scss';
+import IconBase from '../../Icon/IconBase';
+
+type DatePickerInputProps = ComponentProps<'input'> & {
+    asTrigger?: boolean;
+};
+
+const DATE_REGEX = new RegExp(/^[0-9./]*$/);
+
+const DatePickerInput = ({
+    asTrigger,
+    className,
+    ...props
+}: DatePickerInputProps) => {
+    const { date, locale, minDate, maxDate, handleChange } = useDatePicker();
+    const [inputState, setInputState] = useState<
+        'default' | 'invalid' | 'valid'
+    >('default');
+    const [inputValue, setInputValue] = useState(
+        dateFormat(date as Date, locale) || '',
+    );
+
+    const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+        const currentValue = e.target.value;
+        if (!DATE_REGEX.test(currentValue)) return;
+
+        setInputValue(currentValue);
+    };
+
+    const handleClose = () => {
+        handleChange(null);
+    };
+
+    const validate = (value: string) => {
+        if (value === '') {
+            handleChange(null);
+            setInputState('default');
+            return;
+        }
+
+        const isValid = isValidDate(value, locale);
+        if (!isValid) {
+            return setInputState('invalid');
+        }
+
+        const nextDate = constrainDateToRange({ value, minDate, maxDate });
+
+        if (nextDate === date) {
+            const nextInputValue = dateFormat(nextDate, locale);
+            setInputValue(nextInputValue || '');
+        }
+
+        handleChange(nextDate);
+        setInputState('valid');
+    };
+
+    const onBlur = (e: FocusEvent<HTMLInputElement>) => {
+        const value = e.target.value;
+        validate(value);
+    };
+
+    const onPressEnter = (e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.key !== 'Enter') return;
+
+        const value = e.currentTarget.value;
+        validate(value);
+    };
+
+    useEffect(() => {
+        const nextValue = dateFormat(date as Date, locale) || '';
+
+        setInputValue(nextValue);
+        setInputState(nextValue ? 'valid' : 'default');
+    }, [date, locale]);
+
+    if (asTrigger) {
+        return (
+            <DatePickerField
+                value={inputValue || ''}
+                inputState="default"
+                className={clsx(styles.input_trigger, className)}
+                icon={<CalendarIcon />}
+                iconSide="left"
+                readOnly
+                placeholder={props.placeholder}
+            />
+        );
+    }
+
+    return (
+        <DatePickerField
+            className={clsx(
+                styles[`DatePickerField--${inputState}`],
+                className,
+            )}
+            value={inputValue || ''}
+            inputState={inputState}
+            onChange={onChange}
+            onKeyDown={onPressEnter}
+            onBlur={onBlur}
+            icon={
+                inputState === 'valid' ? (
+                    <ErrorCircleIcon handleClose={handleClose} />
+                ) : (
+                    <CalendarIcon />
+                )
+            }
+            iconSide={inputState === 'valid' ? 'right' : 'left'}
+            {...props}
+        />
+    );
+};
+
+export default DatePickerInput;
+
+type DatePickerFieldProps = ComponentProps<'input'> & {
+    inputState: 'default' | 'invalid' | 'valid';
+    icon: JSX.Element;
+    iconSide: 'left' | 'right';
+};
+
+const DatePickerField = ({
+    inputState,
+    icon,
+    iconSide,
+    className,
+    ...props
+}: DatePickerFieldProps) => {
+    return (
+        <div className={clsx(styles.DatePickerField)}>
+            {icon}
+            <input
+                className={clsx(
+                    styles.DatePickerField__input,
+                    styles[`DatePickerField__input--${inputState}`],
+                    className,
+                )}
+                type="text"
+                {...props}
+            />
+            {iconSide === 'right' && icon}
+        </div>
+    );
+};
+
+const ErrorCircleIcon = ({ handleClose }: { handleClose: () => void }) => {
+    return (
+        <IconBase
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            color="#858899"
+            className={styles.DatePickerField__cancelIcon}
+            xmlns="http://www.w3.org/2000/svg"
+            onClick={handleClose}
+        >
+            <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M11.46 10.54L10.54 11.46L8 8.92L5.46 11.46L4.54 10.54L7.08 8L4.54 5.46L5.46 4.54L8 7.08L10.54 4.54L11.46 5.46L8.92 8L11.46 10.54ZM8 1.5C4.412 1.5 1.5 4.412 1.5 8C1.5 11.588 4.412 14.5 8 14.5C11.588 14.5 14.5 11.588 14.5 8C14.5 4.412 11.588 1.5 8 1.5Z"
+            />
+        </IconBase>
+    );
+};
+
+const CalendarIcon = () => {
+    return (
+        <IconBase
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            className={styles.DatePickerField__calendarIcon}
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M10.2 9.25001H11.5V7.95001H10.2V9.25001ZM4.5 9.25001H5.8V7.95001H4.5V9.25001ZM7.35 9.25001H8.65V7.95001H7.35V9.25001ZM3.3 13.2H12.7V6.50001H3.3V13.2ZM12.15 2.50001V1.20001H10.85V2.50001H5.15V1.20001H3.85V2.50001H2V3.50001V6.50001V14.5H14V6.50001V3.50001V2.50001H12.15Z"
+            />
+        </IconBase>
+    );
+};

--- a/packages/my-components/src/DatePicker/DatePickerInput/index.ts
+++ b/packages/my-components/src/DatePicker/DatePickerInput/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DatePickerInput';

--- a/packages/my-components/src/DatePicker/DatePickerReset/DatePickerReset.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerReset/DatePickerReset.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useDatePicker } from '../DatePicker.context';
+import Button from '../../Button';
+
+const DatePickerReset = () => {
+    const { handleChange, defaultDate } = useDatePicker();
+    const reset = () => {
+        handleChange(defaultDate);
+    };
+
+    return (
+        <Button variant="link" type="reset" onClick={reset}>
+            리셋
+        </Button>
+    );
+};
+
+export default DatePickerReset;

--- a/packages/my-components/src/DatePicker/DatePickerReset/index.ts
+++ b/packages/my-components/src/DatePicker/DatePickerReset/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DatePickerReset';

--- a/packages/my-components/src/DatePicker/DatePickerTrigger/DatePickerTrigger.module.scss
+++ b/packages/my-components/src/DatePicker/DatePickerTrigger/DatePickerTrigger.module.scss
@@ -1,0 +1,8 @@
+.trigger {
+    background-color: transparent;
+    border: none;
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    outline: 0;
+}

--- a/packages/my-components/src/DatePicker/DatePickerTrigger/DatePickerTrigger.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerTrigger/DatePickerTrigger.tsx
@@ -1,0 +1,23 @@
+import React, { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react';
+
+import styles from './DatePickerTrigger.module.scss';
+import NoBody from '../../NoBody';
+import { clsx } from 'clsx';
+
+const DatePickerTrigger = forwardRef<
+    ElementRef<typeof NoBody.Trigger>,
+    ComponentPropsWithoutRef<typeof NoBody.Trigger>
+>(({ className, children, ...props }, ref) => {
+    return (
+        <NoBody.Trigger
+            ref={ref}
+            className={clsx(styles.trigger, className)}
+            {...props}
+        >
+            {children}
+        </NoBody.Trigger>
+    );
+});
+DatePickerTrigger.displayName = 'DatePickerTrigger';
+
+export default DatePickerTrigger;

--- a/packages/my-components/src/DatePicker/DatePickerTrigger/index.ts
+++ b/packages/my-components/src/DatePicker/DatePickerTrigger/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DatePickerTrigger';

--- a/packages/my-components/src/DatePicker/index.ts
+++ b/packages/my-components/src/DatePicker/index.ts
@@ -1,0 +1,2 @@
+export { default } from './DatePicker';
+export { type DatePickerDate } from './DatePicker.types';

--- a/packages/my-docs/stories/DatePicker.stories.tsx
+++ b/packages/my-docs/stories/DatePicker.stories.tsx
@@ -1,0 +1,65 @@
+import { Meta, StoryObj } from '@storybook/react';
+import React, { useState } from 'react';
+
+import DatePicker from '../../my-components/src/DatePicker';
+import Button from '../../my-components/src/Button';
+import { type DatePickerDate } from '../../my-components/src/DatePicker';
+
+const meta: Meta<typeof DatePicker> = {
+    title: 'DatePicker',
+    parameters: {
+        layout: 'centered',
+    },
+    tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof DatePicker>;
+
+export const Default: Story = {
+    render: () => {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const [date, setDate] = useState<DatePickerDate>(null);
+
+        return (
+            <div style={{ width: '500px', height: '1000vh' }}>
+                <DatePicker
+                    date={date}
+                    onChangeDate={(date) => setDate(date)}
+                    locale="ko"
+                >
+                    <DatePicker.Trigger>
+                        <DatePicker.Input
+                            asTrigger
+                            placeholder="시작일"
+                            value={date?.toLocaleString('ja')}
+                        />
+                    </DatePicker.Trigger>
+                    <DatePicker.Content
+                        side="top"
+                        sideOffset={10}
+                        align="start"
+                    >
+                        <DatePicker.Header>
+                            <DatePicker.Input placeholder="시작일" />
+                            {/* <DatePicker.Input target="from" /> */}
+                            {/* <DatePicker.Input target="to" /> */}
+                        </DatePicker.Header>
+                        <DatePicker.Calendar
+                            minDate={new Date('2024-07.05')}
+                            maxDate={new Date('2024-07.24')}
+                        />
+                        <DatePicker.Footer>
+                            <DatePicker.Reset />
+
+                            <Button variant="link">A</Button>
+                            <Button variant="primary">B</Button>
+                        </DatePicker.Footer>
+                    </DatePicker.Content>
+                </DatePicker>
+
+                <div>바깥 상태: {date?.toString()}</div>
+            </div>
+        );
+    },
+};


### PR DESCRIPTION
> 아래 섹션들은 모두 선택사항입니다. 필요에 따라, 작성하지 않은 섹션은 지워주세요.

## 📝 변경 사항 요약
> 간략하게 변경 사항을 요약해주세요.

- 데이트 피커 컴포넌트 추가


## 🛠 변경 사항 상세 설명
- DatePicker 관련 서브컴포넌트를 추가했습니다.
  - Trigger, Calendar, Header, Content, Footer, Reset, Input
  - 사용 시에는 Trigger를 제외한 모든 컴포넌트를 Content 내부에서 사용하면 됩니다.
  - Header, Footer 컴포넌트는 스타일만 추가된 깡통 컴포넌트인데 별도로 정의해서 내보내주는 것이 옳은지 아직 잘 판단이 안섭니다ㅠㅠ 일단은 추가해두었습니다.
- minDate, maxDate는 기존 캘린더 컴포넌트와 인터페이스를 맞추기 위해 Root에서 전달 받는 것이 아니라 Calendar 컴포넌트를 통해 전달받습니다.
  - 이후 initialize 함수를 통해 전역으로 끌어올리는 작업을 수행했습니다.
- range 모드에 대해서는 다음 PR에서 추가할 예정입니다.
