### PR TITLE
refactor(types): date 관련 타입 범위 축소

### DIFF
--- a/packages/my-components/package.json
+++ b/packages/my-components/package.json
@@ -34,7 +34,9 @@
     "dependencies": {
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-popover": "^1.1.1",
+        "@types/lodash.once": "^4.1.9",
         "clsx": "^2.1.1",
+        "lodash.once": "^4.1.1",
         "react-calendar": "^5.0.0"
     }
 }

--- a/packages/my-components/src/DatePicker/DatePicker.context.tsx
+++ b/packages/my-components/src/DatePicker/DatePicker.context.tsx
@@ -9,20 +9,6 @@ import {
 } from './DatePicker.types';
 import once from 'lodash.once';
 
-// Context
-// const DatePickerContext = createContext<DatePickerContextType>({
-//     date: undefined,
-//     currentFocus: '',
-//     handleFocus: () => {},
-//     defaultDate: undefined,
-//     handleChange: () => {},
-//     mode: 'single',
-//     locale: 'ko',
-//     initializeRange: () => {},
-//     minDate: undefined,
-//     maxDate: undefined,
-// });
-
 const createDatePickerContext = once(<T extends DateValue | RangeDateValue>() =>
     createContext<DatePickerContextType<T>>({} as DatePickerContextType<T>),
 );
@@ -41,13 +27,7 @@ const DatePickerProvider = <T extends DateValue | RangeDateValue>({
     });
 
     const handleChange = (nextDate: T) => {
-        //! mode range는 일단 무시
-
-        if (mode === 'range') {
-            console.log(nextDate);
-        } else {
-            onChangeDate?.(nextDate);
-        }
+        onChangeDate?.(nextDate);
     };
 
     const initializeRange = ({ minDate, maxDate }: InitializeRangeProps) => {

--- a/packages/my-components/src/DatePicker/DatePicker.context.tsx
+++ b/packages/my-components/src/DatePicker/DatePicker.context.tsx
@@ -2,39 +2,52 @@ import React, { useContext, useState, createContext, useEffect } from 'react';
 
 import {
     DatePickerContextType,
-    DateValue,
     DatePickerProviderProps,
+    DateValue,
     InitializeRangeProps,
+    RangeDateValue,
 } from './DatePicker.types';
+import once from 'lodash.once';
 
 // Context
-const DatePickerContext = createContext<DatePickerContextType>({
-    date: null,
-    defaultDate: null,
-    handleChange: () => {},
-    mode: 'single',
-    locale: 'ko',
-    initializeRange: () => {},
-    minDate: undefined,
-    maxDate: undefined,
-});
+// const DatePickerContext = createContext<DatePickerContextType>({
+//     date: undefined,
+//     currentFocus: '',
+//     handleFocus: () => {},
+//     defaultDate: undefined,
+//     handleChange: () => {},
+//     mode: 'single',
+//     locale: 'ko',
+//     initializeRange: () => {},
+//     minDate: undefined,
+//     maxDate: undefined,
+// });
 
-const DatePickerProvider = ({
+const createDatePickerContext = once(<T extends DateValue | RangeDateValue>() =>
+    createContext<DatePickerContextType<T>>({} as DatePickerContextType<T>),
+);
+const DatePickerProvider = <T extends DateValue | RangeDateValue>({
     date,
     onChangeDate,
-    mode = 'single',
+    mode,
     locale = 'ko',
     children,
-}: DatePickerProviderProps) => {
-    const [defaultDate, setDefaultDate] = useState<DateValue | null>(null);
+}: DatePickerProviderProps<T>) => {
+    const DatePickerContext = createDatePickerContext<T>();
+    const [defaultDate, setDefaultDate] = useState<T>(date);
     const [range, setRange] = useState<InitializeRangeProps>({
         minDate: new Date('1970.01.01'),
         maxDate: new Date('2999.12.31'),
     });
 
-    const handleChange = (date: DateValue) => {
+    const handleChange = (nextDate: T) => {
         //! mode range는 일단 무시
-        onChangeDate?.(date);
+
+        if (mode === 'range') {
+            console.log(nextDate);
+        } else {
+            onChangeDate?.(nextDate);
+        }
     };
 
     const initializeRange = ({ minDate, maxDate }: InitializeRangeProps) => {
@@ -67,7 +80,7 @@ const DatePickerProvider = ({
 export default DatePickerProvider;
 
 export const useDatePicker = () => {
-    const context = useContext(DatePickerContext);
+    const context = useContext(createDatePickerContext());
 
     if (!context) throw new Error('can not find DatePickerContext');
 

--- a/packages/my-components/src/DatePicker/DatePicker.context.tsx
+++ b/packages/my-components/src/DatePicker/DatePicker.context.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useState, createContext, useEffect } from 'react';
 
 import {
     DatePickerContextType,
-    DatePickerDate,
+    DateValue,
     DatePickerProviderProps,
     InitializeRangeProps,
 } from './DatePicker.types';
@@ -26,13 +26,13 @@ const DatePickerProvider = ({
     locale = 'ko',
     children,
 }: DatePickerProviderProps) => {
-    const [defaultDate, setDefaultDate] = useState<DatePickerDate | null>(null);
+    const [defaultDate, setDefaultDate] = useState<DateValue | null>(null);
     const [range, setRange] = useState<InitializeRangeProps>({
         minDate: new Date('1970.01.01'),
         maxDate: new Date('2999.12.31'),
     });
 
-    const handleChange = (date: DatePickerDate) => {
+    const handleChange = (date: DateValue) => {
         //! mode range는 일단 무시
         onChangeDate?.(date);
     };

--- a/packages/my-components/src/DatePicker/DatePicker.tsx
+++ b/packages/my-components/src/DatePicker/DatePicker.tsx
@@ -5,14 +5,14 @@ import DatePickerProvider from './DatePicker.context';
 import DatePickerCalendar from './DatePickerCalendar';
 import DatePickerFooter from './DatePickerFooter';
 import DatePickerHeader from './DatePickerHeader';
-import DatePickerReset from './DatePickerReset/DatePickerReset';
+import DatePickerReset from './DatePickerReset';
 import DatePickerTrigger from './DatePickerTrigger';
 import DatePickerInput from './DatePickerInput';
-
-import { DatePickerProps } from './DatePicker.types';
 import DatePickerContent from './DatePickerContent';
 
-const DatePicker = ({
+import { DatePickerProps, DateValue, RangeDateValue } from './DatePicker.types';
+
+const DatePicker = <T extends DateValue | RangeDateValue>({
     // NoBody props
     open,
     onOpenChange,
@@ -21,8 +21,9 @@ const DatePicker = ({
 
     // DatePickerProvider Props
     children,
+    date,
     ...props
-}: DatePickerProps) => {
+}: DatePickerProps<T>) => {
     return (
         <NoBody
             open={open}
@@ -30,7 +31,9 @@ const DatePicker = ({
             defaultOpen={defaultOpen}
             modal={modal}
         >
-            <DatePickerProvider {...props}>{children}</DatePickerProvider>
+            <DatePickerProvider<typeof date> date={date} {...props}>
+                {children}
+            </DatePickerProvider>
         </NoBody>
     );
 };

--- a/packages/my-components/src/DatePicker/DatePicker.types.ts
+++ b/packages/my-components/src/DatePicker/DatePicker.types.ts
@@ -4,7 +4,7 @@ import NoBody from '../NoBody';
 export type Locale = 'ko' | 'ja' | 'en';
 export type Mode = 'single' | 'range';
 
-export type DatePickerDate = Date | [Date, Date] | null;
+export type DateValue = Date | [Date, Date] | null;
 
 export type InitializeRangeProps = {
     minDate: Date | undefined;
@@ -12,9 +12,9 @@ export type InitializeRangeProps = {
 };
 
 export type DatePickerContextType = {
-    date: DatePickerDate;
-    defaultDate: DatePickerDate;
-    handleChange: (date: DatePickerDate) => void;
+    date: DateValue;
+    defaultDate: DateValue;
+    handleChange: (date: DateValue) => void;
     initializeRange: (range: InitializeRangeProps) => void;
     mode?: Mode;
     locale: Locale;
@@ -23,8 +23,8 @@ export type DatePickerContextType = {
 export type DatePickerProviderProps = {
     mode?: Mode;
     locale?: Locale;
-    date: DatePickerDate;
-    onChangeDate: (date: DatePickerDate) => void;
+    date: DateValue;
+    onChangeDate: (date: DateValue) => void;
     children: ReactNode;
 };
 

--- a/packages/my-components/src/DatePicker/DatePicker.types.ts
+++ b/packages/my-components/src/DatePicker/DatePicker.types.ts
@@ -4,29 +4,30 @@ import NoBody from '../NoBody';
 export type Locale = 'ko' | 'ja' | 'en';
 export type Mode = 'single' | 'range';
 
-export type DateValue = Date | [Date, Date] | null;
+export type DateValue = Date | undefined;
+export type RangeDateValue = [Date | undefined, Date | undefined];
 
 export type InitializeRangeProps = {
     minDate: Date | undefined;
     maxDate: Date | undefined;
 };
 
-export type DatePickerContextType = {
-    date: DateValue;
-    defaultDate: DateValue;
-    handleChange: (date: DateValue) => void;
+export type DatePickerContextType<T extends DateValue | RangeDateValue> = {
+    date: T;
+    defaultDate: T;
+    handleChange: (date: T) => void;
     initializeRange: (range: InitializeRangeProps) => void;
     mode?: Mode;
     locale: Locale;
 } & InitializeRangeProps;
 
-export type DatePickerProviderProps = {
+export type DatePickerProviderProps<T> = {
     mode?: Mode;
     locale?: Locale;
-    date: DateValue;
-    onChangeDate: (date: DateValue) => void;
+    date: T;
+    onChangeDate: (date: T) => void;
     children: ReactNode;
 };
 
-export type DatePickerProps = DatePickerProviderProps &
+export type DatePickerProps<T> = DatePickerProviderProps<T> &
     ComponentProps<typeof NoBody>;

--- a/packages/my-components/src/DatePicker/DatePickerContent/DatePickerContent.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerContent/DatePickerContent.tsx
@@ -2,13 +2,24 @@ import React, { ComponentProps } from 'react';
 import NoBody from '../../NoBody';
 
 import styles from './DatePicker.module.scss';
+import { clsx } from 'clsx';
 
 const DatePickerContent = ({
     children,
+    side = 'bottom',
+    sideOffset = 5,
+    align = 'start',
+    className,
     ...props
 }: ComponentProps<typeof NoBody.Content>) => {
     return (
-        <NoBody.Content {...props} className={styles.content}>
+        <NoBody.Content
+            side={side}
+            sideOffset={sideOffset}
+            align={align}
+            className={clsx(styles.content, className)}
+            {...props}
+        >
             {children}
         </NoBody.Content>
     );

--- a/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.tsx
@@ -45,12 +45,12 @@ const DatePickerInput = ({
     };
 
     const handleClose = () => {
-        handleChange(null);
+        handleChange(undefined);
     };
 
     const validate = (value: string) => {
         if (value === '') {
-            handleChange(null);
+            handleChange(undefined);
             setInputState('default');
             return;
         }

--- a/packages/my-components/src/DatePicker/index.ts
+++ b/packages/my-components/src/DatePicker/index.ts
@@ -1,2 +1,2 @@
 export { default } from './DatePicker';
-export { type DatePickerDate } from './DatePicker.types';
+export { type DateValue } from './DatePicker.types';

--- a/packages/my-docs/stories/DatePicker.stories.tsx
+++ b/packages/my-docs/stories/DatePicker.stories.tsx
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof DatePicker>;
 export const Default: Story = {
     render: () => {
         // eslint-disable-next-line react-hooks/rules-of-hooks
-        const [date, setDate] = useState<DateValue>(null);
+        const [date, setDate] = useState<DateValue>();
 
         return (
             <div style={{ width: '500px', height: '1000vh' }}>

--- a/packages/my-docs/stories/DatePicker.stories.tsx
+++ b/packages/my-docs/stories/DatePicker.stories.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 
 import DatePicker from '../../my-components/src/DatePicker';
 import Button from '../../my-components/src/Button';
-import { type DatePickerDate } from '../../my-components/src/DatePicker';
+import { type DateValue } from '../../my-components/src/DatePicker';
 
 const meta: Meta<typeof DatePicker> = {
     title: 'DatePicker',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof DatePicker>;
 export const Default: Story = {
     render: () => {
         // eslint-disable-next-line react-hooks/rules-of-hooks
-        const [date, setDate] = useState<DatePickerDate>(null);
+        const [date, setDate] = useState<DateValue>(null);
 
         return (
             <div style={{ width: '500px', height: '1000vh' }}>
@@ -31,7 +31,7 @@ export const Default: Story = {
                     <DatePicker.Trigger>
                         <DatePicker.Input
                             asTrigger
-                            placeholder="시작일"
+                            placeholder="기간 선택"
                             value={date?.toLocaleString('ja')}
                         />
                     </DatePicker.Trigger>

--- a/packages/my-docs/stories/DatePicker.stories.tsx
+++ b/packages/my-docs/stories/DatePicker.stories.tsx
@@ -35,11 +35,7 @@ export const Default: Story = {
                             value={date?.toLocaleString('ja')}
                         />
                     </DatePicker.Trigger>
-                    <DatePicker.Content
-                        side="top"
-                        sideOffset={10}
-                        align="start"
-                    >
+                    <DatePicker.Content>
                         <DatePicker.Header>
                             <DatePicker.Input placeholder="시작일" />
                             {/* <DatePicker.Input target="from" /> */}


### PR DESCRIPTION
> 아래 섹션들은 모두 선택사항입니다. 필요에 따라, 작성하지 않은 섹션은 지워주세요.

## 📝 변경 사항 요약
> 간략하게 변경 사항을 요약해주세요.

- 데이트 피커 내에서 사용하는 타입의 범위를 축소했습니다.


## 🛠 변경 사항 상세 설명
- 기존에는 `<DatePicker onChangeDate={date => setDate(date)} />`에서 onChangeDate의 인자인 date의 타입이 DateValue | RangeDateValue로 정의되어 있었습니다.
  - 때문에 사용자는 `onChangeDate={date => setDate(date as DateValue)}` 등과 같이 타입 단언을 해주어야 한다는 불편함이 있었습니다.
  - 이를 해결하기 위해 사용자가 넘겨준 date의 타입에 맞게 내부적으로 타입을 좁혀 제공할 수 있도록 제네릭을 추가했습니다.
  - 이 과정에서 매개변수로 넘겨준 함수를 한 번만 호출하도록 하는 `lodash.once` 패키지를 추가했습니다.
- Content의 기본 props를 정의했습니다.
  - 시안에 따라 `side="bottom"`, `sideOffset={5}`, `align="start"`로 정의했습니다.
  - 이 때, 기존에 사용하던 DatePicker의 인터페이스와 일치시키기 위해 `side -> dropdownDirection` 등으로 수정하는 것에 대해 고민했지만, 다른 NoBody Content와의 인터페이스가 달라질 수 있다는 점에 일단은 보류했습니다.
  - 이 부분은 앞으로 어떻게 할 지 논의하여 추후에 수정하는 것이 좋을 것 같습니다.