### PR TITLE
feat(DatePicker): range mode 추가

### DIFF
--- a/packages/my-components/src/DatePicker/DatePicker.utils.ts
+++ b/packages/my-components/src/DatePicker/DatePicker.utils.ts
@@ -1,4 +1,9 @@
-import { InitializeRangeProps, Locale } from './DatePicker.types';
+import {
+    DateValue,
+    InitializeRangeProps,
+    Locale,
+    RangeDateValue,
+} from './DatePicker.types';
 
 // *** 한자리수 월/일 -> 0 채워주기
 const datePads = (value: number) => {
@@ -6,9 +11,9 @@ const datePads = (value: number) => {
 };
 
 // *** 날짜 formating
-export const dateFormat = (date: Date, locale: Locale) => {
+export const dateFormat = (date: DateValue, locale: Locale) => {
     if (!date) {
-        return null;
+        return '';
     }
     const formatDate = date;
 
@@ -59,4 +64,23 @@ export const constrainDateToRange = ({
     if (maxDate && date > maxDate) return maxDate;
 
     return date;
+};
+
+export const isDateValue = (
+    date: DateValue | RangeDateValue,
+): date is DateValue => {
+    if (Array.isArray(date)) return false;
+    else return true;
+};
+
+export const getSortedDates = (dates: RangeDateValue): RangeDateValue => {
+    const [firstDate, secondDate] = dates;
+
+    if (!firstDate) return [undefined, secondDate];
+    else if (!secondDate) return [firstDate, undefined];
+
+    return [
+        new Date(Math.min(firstDate.getTime(), secondDate.getTime())),
+        new Date(Math.max(firstDate.getTime(), secondDate.getTime())),
+    ];
 };

--- a/packages/my-components/src/DatePicker/DatePickerCalendar/DatePickerCalendar.module.scss
+++ b/packages/my-components/src/DatePicker/DatePickerCalendar/DatePickerCalendar.module.scss
@@ -1,0 +1,3 @@
+.calendar {
+    margin: 0 auto;
+}

--- a/packages/my-components/src/DatePicker/DatePickerCalendar/DatePickerCalendar.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerCalendar/DatePickerCalendar.tsx
@@ -1,15 +1,20 @@
 import React, { ComponentProps, useEffect } from 'react';
+import { LooseValue } from 'react-calendar/dist/cjs/shared/types';
 
 import Calendar from '../../Calendar';
 import { useDatePicker } from '../DatePicker.context';
-import { LooseValue } from 'react-calendar/dist/cjs/shared/types';
+import { DateValue, RangeDateValue } from '../DatePicker.types';
+import styles from './DatePickerCalendar.module.scss';
+
+type ModeDate<T> = T extends 'single' ? DateValue : RangeDateValue;
 
 const DatePickerCalendar = ({
     maxDate,
     minDate,
     ...props
 }: ComponentProps<typeof Calendar>) => {
-    const { date, handleChange, locale, initializeRange } = useDatePicker();
+    const { date, handleChange, mode, locale, initializeRange } =
+        useDatePicker();
 
     useEffect(() => {
         initializeRange({ maxDate, minDate });
@@ -19,10 +24,13 @@ const DatePickerCalendar = ({
     return (
         <Calendar
             value={date as LooseValue}
-            onChange={(date) => handleChange(date as Date)}
+            allowPartialRange
+            onChange={(date) => handleChange(date as ModeDate<typeof mode>)}
             locale={locale}
             minDate={minDate}
             maxDate={maxDate}
+            selectRange={mode === 'range'}
+            className={styles.calendar}
             {...props}
         />
     );

--- a/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.module.scss
+++ b/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.module.scss
@@ -41,16 +41,14 @@
         background-clip: padding-box;
         border: 0.0625rem solid var(--border-color, rgb(225, 225, 232));
         border-radius: 0.5rem;
-        transition:
-            border-color 0.25s ease,
-            box-shadow 0.25s ease;
+        transition: border-color 0.25s ease, box-shadow 0.25s ease;
 
         &:not(&--invalid):hover {
             border-color: var(--semantic-color-border-border-hover, #cdced6);
             outline: 0;
         }
 
-        &:not(&_trigger):not(&--invalid):focus-within {
+        &:not(&--invalid):focus-within {
             border: 1px solid var(--primary, rgb(80, 148, 250));
             outline: 0;
         }

--- a/packages/my-components/src/DatePicker/DatePickerTrigger/DatePickerTrigger.module.scss
+++ b/packages/my-components/src/DatePicker/DatePickerTrigger/DatePickerTrigger.module.scss
@@ -1,8 +1,60 @@
 .trigger {
-    background-color: transparent;
-    border: none;
     width: 100%;
     padding: 0;
     margin: 0;
+
+    background-color: transparent;
+    border: 0.0625rem solid var(--border-color, rgb(225, 225, 232));
+    border-radius: 8px;
     outline: 0;
+    transition: border-color 0.25s ease, box-shadow 0.25s ease;
+
+    &:has(.dateField__input) {
+        &:hover {
+            border-color: var(--semantic-color-border-border-hover, #cdced6);
+            outline: 0;
+        }
+
+        &:focus-visible {
+            border-radius: 0.5rem;
+
+            border: 1px solid var(--primary, rgb(80, 148, 250));
+            outline: 0;
+        }
+    }
+}
+
+.dateField {
+    width: 100%;
+    position: relative;
+
+    &__calendarIcon {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        left: 0.75rem /* 12px -> .75rem */;
+    }
+
+    &__input {
+        box-sizing: border-box;
+        display: block;
+        border: none;
+        border-radius: 8px;
+        width: 100%;
+        height: 2rem;
+        padding: 0.3125rem /* 5px -> .3125rem */ 0.75rem /* 12px -> .75rem */
+            0.3125rem /* 5px -> .3125rem */ 2.25rem /* 36px -> 2.25rem */;
+
+        font-size: 0.875rem;
+        font-weight: 400;
+        line-height: 1.375rem;
+        color: var(--text-normal, rgb(43, 45, 54));
+        background-color: var(--background-normal, rgb(255, 255, 255));
+        background-clip: padding-box;
+
+        &:focus {
+            border: none;
+            outline: none;
+        }
+    }
 }

--- a/packages/my-components/src/DatePicker/DatePickerTrigger/DatePickerTrigger.module.scss
+++ b/packages/my-components/src/DatePicker/DatePickerTrigger/DatePickerTrigger.module.scss
@@ -27,6 +27,8 @@
 .dateField {
     width: 100%;
     position: relative;
+    cursor: pointer;
+    text-align: left;
 
     &__calendarIcon {
         position: absolute;

--- a/packages/my-components/src/DatePicker/DatePickerTrigger/DatePickerTrigger.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerTrigger/DatePickerTrigger.tsx
@@ -1,8 +1,19 @@
-import React, { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react';
+import React, {
+    ComponentPropsWithoutRef,
+    ElementRef,
+    forwardRef,
+    useEffect,
+    useState,
+} from 'react';
+import { clsx } from 'clsx';
+
+import NoBody from '../../NoBody';
+import { Locale, RangeDateValue } from '../DatePicker.types';
+import IconBase from '../../Icon/IconBase';
 
 import styles from './DatePickerTrigger.module.scss';
-import NoBody from '../../NoBody';
-import { clsx } from 'clsx';
+import { useDatePicker } from '../DatePicker.context';
+import { dateFormat, isDateValue } from '../DatePicker.utils';
 
 const DatePickerTrigger = forwardRef<
     ElementRef<typeof NoBody.Trigger>,
@@ -14,10 +25,71 @@ const DatePickerTrigger = forwardRef<
             className={clsx(styles.trigger, className)}
             {...props}
         >
-            {children}
+            {children || <TriggerInput />}
         </NoBody.Trigger>
     );
 });
 DatePickerTrigger.displayName = 'DatePickerTrigger';
 
 export default DatePickerTrigger;
+
+const getInputText = (date: RangeDateValue, locale: Locale) => {
+    const [start, end] = date;
+    const startValue = dateFormat(start, locale);
+    const endValue = dateFormat(end, locale);
+
+    if (startValue && endValue) return `${startValue} - ${endValue}`;
+    else return `${startValue || endValue}`;
+};
+
+const TriggerInput = () => {
+    const { date, locale } = useDatePicker();
+
+    const [inputValue, setInputValue] = useState(() => {
+        if (isDateValue(date)) return dateFormat(date, locale);
+
+        return getInputText(date, locale);
+    });
+
+    useEffect(() => {
+        if (isDateValue(date)) {
+            const nextValue = dateFormat(date, locale);
+            setInputValue(nextValue);
+            return;
+        }
+
+        setInputValue(getInputText(date, locale));
+    }, [date, locale]);
+
+    return (
+        <div className={clsx(styles[`dateField`])}>
+            <input
+                className={clsx(
+                    styles['dateField__input'],
+                    styles[`dateField__input--default`],
+                )}
+                value={inputValue}
+                readOnly
+            />
+            <CalendarIcon />
+        </div>
+    );
+};
+
+const CalendarIcon = () => {
+    return (
+        <IconBase
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            className={styles['dateField__calendarIcon']}
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M10.2 9.25001H11.5V7.95001H10.2V9.25001ZM4.5 9.25001H5.8V7.95001H4.5V9.25001ZM7.35 9.25001H8.65V7.95001H7.35V9.25001ZM3.3 13.2H12.7V6.50001H3.3V13.2ZM12.15 2.50001V1.20001H10.85V2.50001H5.15V1.20001H3.85V2.50001H2V3.50001V6.50001V14.5H14V6.50001V3.50001V2.50001H12.15Z"
+            />
+        </IconBase>
+    );
+};

--- a/packages/my-components/src/DatePicker/DatePickerTrigger/DatePickerTrigger.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerTrigger/DatePickerTrigger.tsx
@@ -63,14 +63,14 @@ const TriggerInput = () => {
 
     return (
         <div className={clsx(styles[`dateField`])}>
-            <input
+            <div
                 className={clsx(
                     styles['dateField__input'],
                     styles[`dateField__input--default`],
                 )}
-                value={inputValue}
-                readOnly
-            />
+            >
+                {inputValue}
+            </div>
             <CalendarIcon />
         </div>
     );

--- a/packages/my-components/src/DatePicker/index.ts
+++ b/packages/my-components/src/DatePicker/index.ts
@@ -1,2 +1,2 @@
 export { default } from './DatePicker';
-export { type DateValue } from './DatePicker.types';
+export { type DateValue, type RangeDateValue } from './DatePicker.types';

--- a/packages/my-docs/stories/DatePicker.stories.tsx
+++ b/packages/my-docs/stories/DatePicker.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 import React, { useState } from 'react';
 
-import DatePicker from '../../my-components/src/DatePicker';
+import DatePicker, { RangeDateValue } from '../../my-components/src/DatePicker';
 import Button from '../../my-components/src/Button';
 import { type DateValue } from '../../my-components/src/DatePicker';
 
@@ -55,6 +55,95 @@ export const Default: Story = {
                 </DatePicker>
 
                 <div>바깥 상태: {date?.toString()}</div>
+            </div>
+        );
+    },
+};
+
+export const WithSidebar: Story = {
+    render: () => {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const [date, setDate] = useState<RangeDateValue>();
+
+        return (
+            <div style={{ width: '500px', height: '1000vh' }}>
+                <DatePicker
+                    date={date}
+                    onChangeDate={(date) => setDate(date)}
+                    locale="ko"
+                    mode="range"
+                >
+                    <DatePicker.Trigger>
+                        <DatePicker.Input
+                            asTrigger
+                            placeholder="기간 선택"
+                            value={date?.toLocaleString('ja')}
+                        />
+                    </DatePicker.Trigger>
+                    <DatePicker.Content>
+                        <DatePicker.Header>
+                            <DatePicker.Input
+                                placeholder="시작일"
+                                target="start"
+                            />
+                            <DatePicker.Input
+                                placeholder="종료일"
+                                target="end"
+                            />
+                        </DatePicker.Header>
+                        <div style={{ display: 'flex' }}>
+                            <div
+                                style={{
+                                    flex: 1,
+                                    display: 'flex',
+                                    flexDirection: 'column',
+                                }}
+                            >
+                                <button
+                                    onClick={() => {
+                                        const date = new Date();
+                                        date.setMonth(date.getMonth() - 1);
+                                        setDate([date, new Date()]);
+                                    }}
+                                >
+                                    최근 한달
+                                </button>
+                                <button
+                                    onClick={() => {
+                                        const date = new Date();
+                                        date.setDate(date.getDate() - 7);
+                                        setDate([date, new Date()]);
+                                    }}
+                                >
+                                    최근 일주일
+                                </button>
+                                <button
+                                    onClick={() =>
+                                        setDate([new Date(), new Date()])
+                                    }
+                                >
+                                    오늘
+                                </button>
+                            </div>
+                            <DatePicker.Calendar />
+                        </div>
+                        <DatePicker.Footer>
+                            <DatePicker.Reset />
+
+                            <Button variant="link">A</Button>
+                            <Button variant="primary">B</Button>
+                        </DatePicker.Footer>
+                    </DatePicker.Content>
+                </DatePicker>
+
+                <div style={{ marginTop: 10 }}>
+                    <span>date 상태: </span>
+                    <br />
+                    <br />
+                    <span>{date?.[0]?.toLocaleDateString()}</span>
+                    <span> ~ </span>
+                    <span>{date?.[1]?.toLocaleDateString()}</span>
+                </div>
             </div>
         );
     },

--- a/packages/my-docs/stories/DatePicker.stories.tsx
+++ b/packages/my-docs/stories/DatePicker.stories.tsx
@@ -28,18 +28,10 @@ export const Default: Story = {
                     onChangeDate={(date) => setDate(date)}
                     locale="ko"
                 >
-                    <DatePicker.Trigger>
-                        <DatePicker.Input
-                            asTrigger
-                            placeholder="기간 선택"
-                            value={date?.toLocaleString('ja')}
-                        />
-                    </DatePicker.Trigger>
+                    <DatePicker.Trigger />
                     <DatePicker.Content>
                         <DatePicker.Header>
                             <DatePicker.Input placeholder="시작일" />
-                            {/* <DatePicker.Input target="from" /> */}
-                            {/* <DatePicker.Input target="to" /> */}
                         </DatePicker.Header>
                         <DatePicker.Calendar
                             minDate={new Date('2024-07.05')}
@@ -73,13 +65,7 @@ export const WithSidebar: Story = {
                     locale="ko"
                     mode="range"
                 >
-                    <DatePicker.Trigger>
-                        <DatePicker.Input
-                            asTrigger
-                            placeholder="기간 선택"
-                            value={date?.toLocaleString('ja')}
-                        />
-                    </DatePicker.Trigger>
+                    <DatePicker.Trigger />
                     <DatePicker.Content>
                         <DatePicker.Header>
                             <DatePicker.Input


### PR DESCRIPTION
> 아래 섹션들은 모두 선택사항입니다. 필요에 따라, 작성하지 않은 섹션은 지워주세요.

## 📝 변경 사항 요약
> 간략하게 변경 사항을 요약해주세요.

- 데이터 피커에 Range 모드 추가


## 🛠 변경 사항 상세 설명
- 데이터 피커에 mode="range" 프로퍼티를 추가합니다.
- Trigger 컴포넌트에 children을 추가하지 않을 시 렌더링 될 default component를 추가합니다.
  - 해당 default component의 존재 유무에 따라 trigger(button)의 스타일에 차이가 발생합니다.
  - default component가 존재할 시, 마우스 호버 했을 경우와 포커스(키보드로만, focus-visible) 되었을 때 테두리 관련 스타일이 적용됩니다.
  - ~관련해서 trigger의 input 컴포넌트는 tab으로 접근할 필요가 없다는 생각이 들어 tab index를 -1로 지정하는 것에 대해 고민 중입니다.~
    - 굳이 마크업이 input일 필요가 없다고 생각이 들어 div 태그로 변경했습니다.