### PR TITLE
fix(DatePickerProvider): range 모드에서 초기 date가 undefined일 때 text input 동작 수정

### DIFF
--- a/packages/my-components/src/DatePicker/DatePicker.context.tsx
+++ b/packages/my-components/src/DatePicker/DatePicker.context.tsx
@@ -36,6 +36,10 @@ const DatePickerProvider = <T extends DateValue | RangeDateValue>({
     };
 
     useEffect(() => {
+        if (mode === 'range' && date === undefined) {
+            handleChange([undefined, undefined] as T);
+        }
+
         setDefaultDate(date);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);

--- a/packages/my-docs/stories/DatePicker.stories.tsx
+++ b/packages/my-docs/stories/DatePicker.stories.tsx
@@ -163,9 +163,15 @@ export const WithSidebar: Story = {
                     <span>date 상태: </span>
                     <br />
                     <br />
-                    <span>{date?.[0]?.toLocaleDateString()}</span>
+                    <span>
+                        {`${date?.[0]}`}
+                        {date?.[0]?.toLocaleDateString()}
+                    </span>
                     <span> ~ </span>
-                    <span>{date?.[1]?.toLocaleDateString()}</span>
+                    <span>
+                        {`${date?.[1]}`}
+                        {date?.[1]?.toLocaleDateString()}
+                    </span>
                 </div>
             </div>
         );


### PR DESCRIPTION
> 아래 섹션들은 모두 선택사항입니다. 필요에 따라, 작성하지 않은 섹션은 지워주세요.

## 📝 변경 사항 요약
> 간략하게 변경 사항을 요약해주세요.

- range 모드에서 기본 입력 date 타입이 undefined일 경우 헤더 내부 input의 동작 수정

## 🛠 변경 사항 상세 설명
- range 모드에서 초기 date type이 undefined일 경우 헤더 내부의 인풋에 직접 텍스트(ex. 2024.7.26)를 입력했을 때 start, end 인풋이 함께 바뀌는 버그가 있습니다.
  - 그 이유는 넘겨 받은 date의 실제 타입을 검사해서 mode === 'range'를 판별하는데, date가 undefined일 때는 모드가 range이더라도 date type이 RangeDateValue(-> [undefined, undefined]) 형태가 아니므로 single로 인식하기 때문입니다.
  - 따라서 mode가 range이고, date가 undefined일 때는  date를 [undefined, undefined]로 초기화하도록 설정하였습니다.