### PR TITLE
refactor(DatePickerInputs): DatePickerInputs를 완성형으로 수정

### DIFF
--- a/packages/my-components/src/DatePicker/DatePicker.tsx
+++ b/packages/my-components/src/DatePicker/DatePicker.tsx
@@ -5,7 +5,7 @@ import DatePickerProvider from './DatePicker.context';
 import DatePickerCalendar from './DatePickerCalendar';
 import DatePickerReset from './DatePickerReset';
 import DatePickerTrigger from './DatePickerTrigger';
-import DatePickerInput from './DatePickerInput';
+import DatePickerInputs from './DatePickerInputs';
 import DatePickerContent from './DatePickerContent';
 
 import { DatePickerProps, DateValue, RangeDateValue } from './DatePicker.types';
@@ -40,6 +40,6 @@ DatePicker.Trigger = DatePickerTrigger;
 DatePicker.Calendar = DatePickerCalendar;
 DatePicker.Content = DatePickerContent;
 DatePicker.Reset = DatePickerReset;
-DatePicker.Input = DatePickerInput;
+DatePicker.Inputs = DatePickerInputs;
 
 export default DatePicker;

--- a/packages/my-components/src/DatePicker/DatePicker.types.ts
+++ b/packages/my-components/src/DatePicker/DatePicker.types.ts
@@ -7,6 +7,8 @@ export type Mode = 'single' | 'range';
 export type DateValue = Date | undefined;
 export type RangeDateValue = [Date | undefined, Date | undefined];
 
+export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
+
 export type InitializeRangeProps = {
     minDate: Date | undefined;
     maxDate: Date | undefined;

--- a/packages/my-components/src/DatePicker/DatePickerInput/index.ts
+++ b/packages/my-components/src/DatePicker/DatePickerInput/index.ts
@@ -1,1 +1,0 @@
-export { default } from './DatePickerInput';

--- a/packages/my-components/src/DatePicker/DatePickerInputs/DatePickerInputs.module.scss
+++ b/packages/my-components/src/DatePicker/DatePickerInputs/DatePickerInputs.module.scss
@@ -1,5 +1,7 @@
-.input_trigger {
-    cursor: pointer;
+.inputs {
+    display: flex;
+    gap: 0.5rem;
+    width: 100%;
 }
 
 .DatePickerField {
@@ -18,10 +20,6 @@
         transform: translateY(-50%);
         right: 0.75rem /* 12px -> .75rem */;
         cursor: pointer;
-    }
-
-    & + & {
-        margin-left: 0.5rem /* 8px -> .5rem */;
     }
 
     // reactstrap style

--- a/packages/my-components/src/DatePicker/DatePickerInputs/DatePickerInputs.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerInputs/DatePickerInputs.tsx
@@ -17,9 +17,9 @@ import {
     isValidDate,
 } from '../DatePicker.utils';
 
-import styles from './DatePickerInput.module.scss';
+import styles from './DatePickerInputs.module.scss';
 import IconBase from '../../Icon/IconBase';
-import { RangeDateValue } from '../DatePicker.types';
+import { DateValue, Optional, RangeDateValue } from '../DatePicker.types';
 
 type InputState = 'default' | 'invalid' | 'valid';
 type DatePickerInputProps = ComponentProps<'input'> & {
@@ -132,7 +132,54 @@ const DatePickerInput = ({
     );
 };
 
-export default DatePickerInput;
+type DefaultInputsProps = {
+    placeholder: string;
+    startPlaceholder: string;
+    endPlaceholder: string;
+};
+type SingleInputsProps = Optional<
+    DefaultInputsProps,
+    'endPlaceholder' | 'startPlaceholder'
+>;
+type RangeInputsProps = Optional<DefaultInputsProps, 'placeholder'>;
+type InputsProps<T> = T extends DateValue
+    ? SingleInputsProps
+    : RangeInputsProps;
+
+const DatePickerInputs = (props: InputsProps<typeof date>) => {
+    const { date } = useDatePicker();
+
+    if (isDateValue(date) && (props.startPlaceholder || props.endPlaceholder)) {
+        console.warn(
+            'single 모드일 때는 startPlaceholder 혹은 endPlaceholder를 이용할 수 없습니다.',
+        );
+    }
+
+    if (!isDateValue(date) && props.placeholder) {
+        console.warn('range 모드일 때는 placeholder를 이용할 수 없습니다.');
+    }
+
+    return (
+        <div className={styles.inputs}>
+            {isDateValue(date) ? (
+                <DatePickerInput placeholder={props.placeholder} />
+            ) : (
+                <>
+                    <DatePickerInput
+                        target="start"
+                        placeholder={props.startPlaceholder}
+                    />
+                    <DatePickerInput
+                        target="end"
+                        placeholder={props.endPlaceholder}
+                    />
+                </>
+            )}
+        </div>
+    );
+};
+
+export default DatePickerInputs;
 
 const ErrorCircleIcon = ({ handleClose }: { handleClose: () => void }) => {
     return (

--- a/packages/my-components/src/DatePicker/DatePickerInputs/index.ts
+++ b/packages/my-components/src/DatePicker/DatePickerInputs/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DatePickerInputs';

--- a/packages/my-docs/stories/DatePicker.stories.tsx
+++ b/packages/my-docs/stories/DatePicker.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import { Meta, StoryObj } from '@storybook/react';
 import React, { ReactNode, useState } from 'react';
 
@@ -43,7 +44,7 @@ export const Default: Story = {
                                     '0.0625rem solid var(--border-color, rgb(225, 225, 232))',
                             }}
                         >
-                            <DatePicker.Input placeholder="시작일" />
+                            <DatePicker.Inputs placeholder="날짜를 선택해주세요." />
                         </div>
                         <DatePicker.Calendar
                             minDate={new Date('2024-07.05')}
@@ -104,13 +105,9 @@ export const WithSidebar: Story = {
                                     '0.0625rem solid var(--border-color, rgb(225, 225, 232))',
                             }}
                         >
-                            <DatePicker.Input
-                                placeholder="시작일"
-                                target="start"
-                            />
-                            <DatePicker.Input
-                                placeholder="시작일"
-                                target="end"
+                            <DatePicker.Inputs
+                                startPlaceholder="시작일"
+                                endPlaceholder="종료일"
                             />
                         </div>
                         <div style={{ display: 'flex' }}>
@@ -211,3 +208,64 @@ const RangeButton = ({
         </button>
     );
 };
+
+// export const RangeWithSeparatedDate: Story = {
+//     render: () => {
+//         const [startDate, setStartDate] = useState<DateValue>();
+//         const [endDate, setEndDate] = useState<DateValue>();
+//         const handleDate = (date: RangeDateValue) => {
+//             const [start, end] = date;
+
+//             setStartDate(start);
+//             setEndDate(end);
+//         };
+
+//         return (
+//             <div style={{ width: '500px', height: '1000vh' }}>
+//                 <DatePicker
+//                     date={[startDate, endDate]}
+//                     onChangeDate={(date) => handleDate(date)}
+//                     locale="ko"
+//                     mode="range"
+//                 >
+//                     <DatePicker.Trigger />
+//                     <DatePicker.Content
+//                         style={{
+//                             backgroundColor: 'white',
+//                         }}
+//                     >
+//                         <div
+//                             style={{
+//                                 padding: '12px 16px 16px',
+//                                 borderBottom:
+//                                     '0.0625rem solid var(--border-color, rgb(225, 225, 232))',
+//                             }}
+//                         >
+//                             <DatePicker.Input placeholder="시작일" />
+//                         </div>
+//                         <DatePicker.Calendar
+//                             minDate={new Date('2024-07.05')}
+//                             maxDate={new Date('2024-07.24')}
+//                         />
+//                         <div
+//                             style={{
+//                                 display: 'flex',
+//                                 padding: '12px 16px 16px',
+//                                 borderTop:
+//                                     '0.0625rem solid var(--border-color, rgb(225, 225, 232))',
+//                             }}
+//                         >
+//                             <DatePicker.Reset />
+
+//                             <Button variant="link">A</Button>
+//                             <Button variant="primary">B</Button>
+//                         </div>
+//                     </DatePicker.Content>
+//                 </DatePicker>
+
+//                 <div>start date: {startDate?.toString()}</div>
+//                 <div>end date: {endDate?.toString()}</div>
+//             </div>
+//         );
+//     },
+// };


### PR DESCRIPTION
> 아래 섹션들은 모두 선택사항입니다. 필요에 따라, 작성하지 않은 섹션은 지워주세요.

## 📝 변경 사항 요약
> 간략하게 변경 사항을 요약해주세요.

- 데이터 피커 Inputs를 완성형으로 수정


## 🛠 변경 사항 상세 설명
- DatePicker의 모드와 헤더에 들어갈 Input의 개수는 대응 관계로 예상이 됩니다.
  - range - 2개
  - single - 1개
- 따라서 Input을 직접 입력하는 것이 아니라 `<DatePicker.Inputs />`와 같은 형태로 추가하기만 하면 개수나 start, end 옵션은 컴포넌트 내부에서 알아서 결정하도록 수정했습니다.

## 💬 논의사항
- native input에 직접 접근하여 옵션을 수정하기는 어려워 보입니다.
  - 만일 `<DatePicker.Inputs />` 내부의 input에 접근해서 다양한 속성을 사용해야 하는 경우가 생긴다면, 그 때 새로운 인터페이스를 고민해보는 것이 좋을 것 같습니다.
- 동일한 이유로 `<DatePicker.Inputs />` 내부 input에 placeholder를 직접 바인딩 하는 것이 어렵습니다.
  - 따라서 조건부 타입을 통해 `startPlaceholder`, `endPlaceholder`는 항상 같이 전달 받도록 했습니다.
  - 하지만 정확하게 `startPlaceholder, endPlaceholder` / `placeholder`가 양분되도록 하지는 못했기 때문에 의도와 다르게 사용했을 경우 warning을 띄우도록 구현했습니다.