### PR TITLE
fix(DatePickerProvider): range 모드에서 date가 undefined일 때 reset 동작 버그 수정

### DIFF
--- a/packages/my-components/src/DatePicker/DatePicker.context.tsx
+++ b/packages/my-components/src/DatePicker/DatePicker.context.tsx
@@ -38,6 +38,9 @@ const DatePickerProvider = <T extends DateValue | RangeDateValue>({
     useEffect(() => {
         if (mode === 'range' && date === undefined) {
             handleChange([undefined, undefined] as T);
+            setDefaultDate([undefined, undefined] as T);
+
+            return;
         }
 
         setDefaultDate(date);


### PR DESCRIPTION
> 아래 섹션들은 모두 선택사항입니다. 필요에 따라, 작성하지 않은 섹션은 지워주세요.

## 📝 변경 사항 요약
> 간략하게 변경 사항을 요약해주세요.

- range 모드에서 date가 undefined일 때 defaultDate 초기화 시 [undefined, undefined]로 초기화 하도록 수정합니다.


## 🛠 변경 사항 상세 설명
- 기존에는 range 모드에서 date가 undefined일 때 reset 버튼 클릭 시 undefined로 초기화되어 inputs가 하나로 변경되는 버그가 있습니다.
- 따라서 defaultDate 초기화 시 range 모드이고 date가 undefined인 경우에 대한 예외 처리를 하여 [undefined, undefined]로 초기화 하도록 수정합니다.