### PR TITLE
feat(Stack): Stack 컴포넌트 추가

### DIFF
--- a/packages/my-components/package.json
+++ b/packages/my-components/package.json
@@ -37,6 +37,7 @@
         "@types/lodash.once": "^4.1.9",
         "clsx": "^2.1.1",
         "lodash.once": "^4.1.1",
-        "react-calendar": "^5.0.0"
+        "react-calendar": "^5.0.0",
+        "react-use": "^17.5.1"
     }
 }

--- a/packages/my-components/src/Stack/Stack.module.scss
+++ b/packages/my-components/src/Stack/Stack.module.scss
@@ -1,0 +1,11 @@
+:root {
+    --sm: 8px;
+    --md: 16px;
+    --lg: 24px;
+}
+
+.stack {
+    display: flex;
+    flex-direction: column;
+    justify-content: start;
+}

--- a/packages/my-components/src/Stack/Stack.tsx
+++ b/packages/my-components/src/Stack/Stack.tsx
@@ -1,0 +1,39 @@
+import { useCss } from 'react-use';
+import { clsx } from 'clsx';
+import React, { forwardRef } from 'react';
+
+import styles from './Stack.module.scss';
+import { StackProps } from './Stack.types';
+
+const Stack = forwardRef<HTMLDivElement, StackProps>(
+    (
+        {
+            align = 'start',
+            spacing = 'md',
+            justify = 'start',
+            className,
+            ...props
+        },
+        ref,
+    ) => {
+        const gap =
+            typeof spacing === 'number' ? `${spacing}px` : `var(--${spacing})`;
+
+        const css = useCss({
+            justifyContent: justify,
+            alignItems: align,
+            gap,
+        });
+
+        return (
+            <div
+                ref={ref}
+                className={clsx(styles.stack, css, className)}
+                {...props}
+            />
+        );
+    },
+);
+Stack.displayName = 'Stack';
+
+export default Stack;

--- a/packages/my-components/src/Stack/Stack.types.ts
+++ b/packages/my-components/src/Stack/Stack.types.ts
@@ -1,0 +1,9 @@
+import { ComponentPropsWithoutRef, CSSProperties } from 'react';
+
+type Spacing = 'sm' | 'md' | 'lg' | number;
+
+export type StackProps = {
+    align?: CSSProperties['alignItems'];
+    justify?: CSSProperties['justifyContent'];
+    spacing?: Spacing;
+} & ComponentPropsWithoutRef<'div'>;

--- a/packages/my-components/src/Stack/index.ts
+++ b/packages/my-components/src/Stack/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Stack';

--- a/packages/my-docs/stories/DatePicker.stories.tsx
+++ b/packages/my-docs/stories/DatePicker.stories.tsx
@@ -7,6 +7,7 @@ import DatePicker, {
     DateValue,
 } from '../../my-components/src/DatePicker';
 import Button from '../../my-components/src/Button';
+import Stack from '../../my-components/src/Stack';
 
 const meta: Meta<typeof DatePicker> = {
     title: 'DatePicker',
@@ -111,11 +112,9 @@ export const WithSidebar: Story = {
                             />
                         </div>
                         <div style={{ display: 'flex' }}>
-                            <div
+                            <Stack
+                                spacing="sm"
                                 style={{
-                                    flex: 1,
-                                    display: 'flex',
-                                    flexDirection: 'column',
                                     width: '150px',
                                     padding: '12px 4px',
                                     borderRight:
@@ -137,7 +136,7 @@ export const WithSidebar: Story = {
                                 >
                                     오늘
                                 </RangeButton>
-                            </div>
+                            </Stack>
                             <DatePicker.Calendar />
                         </div>
                         <div

--- a/packages/my-docs/stories/Stack.stories.tsx
+++ b/packages/my-docs/stories/Stack.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof Stack> = {
     argTypes: {
         align: {
             control: { type: 'inline-radio' },
-            options: ['start', 'center', 'end'],
+            options: ['start', 'center', 'end', 'stretch'],
         },
         justify: {
             control: { type: 'inline-radio' },
@@ -41,28 +41,28 @@ export const Default: Story = {
                     <StackItem
                         bgColor="red"
                         label="1"
-                        width={100}
+                        minWidth={100}
                         height={50}
                     />
 
                     <StackItem
                         bgColor="blue"
                         label="2"
-                        width={50}
+                        minWidth={50}
                         height={200}
                     />
 
                     <StackItem
                         bgColor="green"
                         label="3"
-                        width={150}
+                        minWidth={150}
                         height={150}
                     />
 
                     <StackItem
                         bgColor="yellow"
                         label="4"
-                        width={200}
+                        minWidth={200}
                         height={100}
                     />
                 </Stack>
@@ -84,28 +84,28 @@ export const NumberSpacing: Story = {
                     <StackItem
                         bgColor="red"
                         label="1"
-                        width={100}
+                        minWidth={100}
                         height={50}
                     />
 
                     <StackItem
                         bgColor="blue"
                         label="2"
-                        width={50}
+                        minWidth={50}
                         height={200}
                     />
 
                     <StackItem
                         bgColor="green"
                         label="3"
-                        width={150}
+                        minWidth={150}
                         height={150}
                     />
 
                     <StackItem
                         bgColor="yellow"
                         label="4"
-                        width={200}
+                        minWidth={200}
                         height={100}
                     />
                 </Stack>
@@ -117,7 +117,7 @@ export const NumberSpacing: Story = {
 const StackItem = (props: {
     bgColor: string;
     label: string;
-    width: number;
+    minWidth: number;
     height: number;
 }) => {
     return (

--- a/packages/my-docs/stories/Stack.stories.tsx
+++ b/packages/my-docs/stories/Stack.stories.tsx
@@ -1,0 +1,131 @@
+import { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import Stack from '../../my-components/src/Stack';
+
+const meta: Meta<typeof Stack> = {
+    title: 'Stack',
+    component: Stack,
+    parameters: {
+        layout: 'centered',
+    },
+    tags: ['autodocs'],
+    argTypes: {
+        align: {
+            control: { type: 'inline-radio' },
+            options: ['start', 'center', 'end'],
+        },
+        justify: {
+            control: { type: 'inline-radio' },
+            options: ['start', 'center', 'end'],
+        },
+        spacing: {
+            control: { type: 'inline-radio' },
+            options: ['sm', 'md', 'lg'],
+        },
+    },
+    args: {
+        align: 'center',
+        spacing: 'md',
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof Stack>;
+
+export const Default: Story = {
+    render: (args) => {
+        return (
+            <div>
+                <Stack {...args}>
+                    <StackItem
+                        bgColor="red"
+                        label="1"
+                        width={100}
+                        height={50}
+                    />
+
+                    <StackItem
+                        bgColor="blue"
+                        label="2"
+                        width={50}
+                        height={200}
+                    />
+
+                    <StackItem
+                        bgColor="green"
+                        label="3"
+                        width={150}
+                        height={150}
+                    />
+
+                    <StackItem
+                        bgColor="yellow"
+                        label="4"
+                        width={200}
+                        height={100}
+                    />
+                </Stack>
+            </div>
+        );
+    },
+};
+
+export const NumberSpacing: Story = {
+    argTypes: {
+        spacing: {
+            control: 'number',
+        },
+    },
+    render: (args) => {
+        return (
+            <div>
+                <Stack {...args}>
+                    <StackItem
+                        bgColor="red"
+                        label="1"
+                        width={100}
+                        height={50}
+                    />
+
+                    <StackItem
+                        bgColor="blue"
+                        label="2"
+                        width={50}
+                        height={200}
+                    />
+
+                    <StackItem
+                        bgColor="green"
+                        label="3"
+                        width={150}
+                        height={150}
+                    />
+
+                    <StackItem
+                        bgColor="yellow"
+                        label="4"
+                        width={200}
+                        height={100}
+                    />
+                </Stack>
+            </div>
+        );
+    },
+};
+
+const StackItem = (props: {
+    bgColor: string;
+    label: string;
+    width: number;
+    height: number;
+}) => {
+    return (
+        <div
+            style={{
+                backgroundColor: props.bgColor,
+                ...props,
+            }}
+        ></div>
+    );
+};


### PR DESCRIPTION
> 아래 섹션들은 모두 선택사항입니다. 필요에 따라, 작성하지 않은 섹션은 지워주세요.

## 📝 변경 사항 요약
> 간략하게 변경 사항을 요약해주세요.

- Stack 컴포넌트 추가


## 🛠 변경 사항 상세 설명
- 자식 요소를 위에서부터 차례로 쌓이도록 하는 `Stack` 컴포넌트를 생성했습니다.
  - 관련해서 `react-use`를 설치하고 `useCss`라는 함수를 이용했습니다.
  - 해당 함수는 전달 받은 CSS Properties를 포함하는 하나의 스타일시트를 생성하고, 이를 className에 할당하여 스타일을 적용하는 방식으로 동작합니다.
  - 이 함수를 사용한 이유는 `Stack` 컴포넡트가 `justifyContent`나 `gap` 등의 프로퍼티를 전달 받았을 때 컴포넌트 내에서 모든 값에 대한 스타일을 지정해주어야 합니다.
  - 하지만 `gap`의 경우에는 `sm`, `md`, `lg` 등의 제한된 옵션으로는 다양한 예외 상황을 커버할 수 없을 것이라 생각했습니다.
  - 따라서 미리 스타일을 지정하지 않고도 전달 받은 props 만으로 다양한 스타일을 생성할 수 있는 방법을 고민하다가 해당 방법을 사용했습니다.

## 💬 논의사항
- 보완하고 싶은 점은 해당 함수를 통해 만들어진 className은 `react-use-***` 등의 형태를 갖습니다. 또 한 번의 함수 호출로 여러 스타일을 지정하고자 하는 경우에는 제약이 있습니다.
  ```tsx
  // ex.
  const styles = useCss({
      root: {},
      content: {}
  })
  ```
  - 따라서 `useCss`를 vapor components에 맞게 직접 구현하는 방법도 고민해보면 좋을 것 같습니다. ~(생각보다 내부 구현이 어렵지 않게 되어 있어서 라이브러리에 대한 학습만 하면 될 것 같아서...)~
  - [useCss 소스코드](https://github.com/streamich/react-use/blob/master/src/useCss.ts)