### PR TITLE
refactor(DatePicker): date 타입 수정 및 onChange 버그 수정

### DIFF
--- a/packages/my-components/src/DatePicker/DatePicker.context.tsx
+++ b/packages/my-components/src/DatePicker/DatePicker.context.tsx
@@ -39,8 +39,9 @@ const DatePickerProvider = <T extends DateType>({
 
     useEffect(() => {
         if (mode === 'range' && date === undefined) {
-            handleChange([null, null] as T);
-            setDefaultDate([null, null] as T);
+            const initialDate = { from: null, to: null };
+            handleChange(initialDate as T);
+            setDefaultDate(initialDate as T);
 
             return;
         }

--- a/packages/my-components/src/DatePicker/DatePicker.types.ts
+++ b/packages/my-components/src/DatePicker/DatePicker.types.ts
@@ -1,12 +1,14 @@
 import { ComponentProps, ReactNode } from 'react';
 import NoBody from '../NoBody';
-import { Range } from 'react-calendar/dist/cjs/shared/types';
 
 export type Locale = 'ko' | 'ja' | 'en';
 export type Mode = 'single' | 'range';
 
 export type DateValue = Date | null;
-export type RangeDateValue = Range<DateValue>;
+export type RangeDateValue = {
+    from: DateValue;
+    to: DateValue;
+};
 export type DateType = DateValue | RangeDateValue;
 
 export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;

--- a/packages/my-components/src/DatePicker/DatePicker.types.ts
+++ b/packages/my-components/src/DatePicker/DatePicker.types.ts
@@ -37,9 +37,3 @@ export type DatePickerProviderProps<T> = {
 
 export type DatePickerProps<T> = DatePickerProviderProps<T> &
     ComponentProps<typeof NoBody>;
-
-export type IsDateFormatProps = { y: string; m: string; d: string };
-
-export type CheckRangeProps = {
-    value: string;
-} & InitializeRangeProps;

--- a/packages/my-components/src/DatePicker/DatePicker.utils.ts
+++ b/packages/my-components/src/DatePicker/DatePicker.utils.ts
@@ -1,5 +1,6 @@
 import {
     CheckRangeProps,
+    DateType,
     DateValue,
     IsDateFormatProps,
     Locale,
@@ -16,6 +17,7 @@ export const dateFormat = (date: DateValue, locale: Locale) => {
     if (!date) {
         return '';
     }
+
     const formatDate = date;
 
     const y = formatDate.getFullYear();
@@ -65,20 +67,21 @@ export const constrainDateToRange = ({
 
 export const isDateValue = (
     // !다른 방법을 고민해보기
-    date: DateValue | RangeDateValue,
+    date: DateType,
 ): date is DateValue => {
-    if (Array.isArray(date)) return false;
+    if (!date) return true;
+    if ('from' in date && 'to' in date) return false;
     else return true;
 };
 
 export const getSortedDates = (dates: RangeDateValue): RangeDateValue => {
-    const [firstDate, secondDate] = dates;
+    const { from, to } = dates;
 
-    if (!firstDate) return [null, secondDate];
-    else if (!secondDate) return [firstDate, null];
+    if (!from) return { from: null, to };
+    else if (!to) return { from, to: null };
 
-    return [
-        new Date(Math.min(firstDate.getTime(), secondDate.getTime())),
-        new Date(Math.max(firstDate.getTime(), secondDate.getTime())),
-    ];
+    return {
+        from: new Date(Math.min(from.getTime(), to.getTime())),
+        to: new Date(Math.max(from.getTime(), to.getTime())),
+    };
 };

--- a/packages/my-components/src/DatePicker/DatePicker.utils.ts
+++ b/packages/my-components/src/DatePicker/DatePicker.utils.ts
@@ -1,8 +1,6 @@
 import {
-    CheckRangeProps,
     DateType,
     DateValue,
-    IsDateFormatProps,
     Locale,
     RangeDateValue,
 } from './DatePicker.types';
@@ -26,43 +24,6 @@ export const dateFormat = (date: DateValue, locale: Locale) => {
 
     if (locale === 'ko') return `${y}.${m}.${d}`;
     return `${m}.${d}.${y}`;
-};
-
-export const isDateFormat = ({ y, m, d }: IsDateFormatProps) => {
-    const date = new Date(`${y}-${m}-${d}`);
-
-    if (!date.getTime()) return false;
-    else return true;
-};
-
-export const getYMD = (value: string, locale: Locale) => {
-    const dates = value.replace(/[./]/g, ' ').split(' ');
-    let y, m, d;
-
-    if (locale === 'ko') {
-        [y, m, d] = dates;
-    } else {
-        [m, d, y] = dates;
-    }
-
-    return { y, m, d };
-};
-
-export const isValidDate = (value: string, locale: Locale) => {
-    return isDateFormat(getYMD(value, locale));
-};
-
-export const constrainDateToRange = ({
-    value,
-    minDate,
-    maxDate,
-}: CheckRangeProps) => {
-    const date = new Date(value);
-
-    if (minDate && date < minDate) return minDate;
-    if (maxDate && date > maxDate) return maxDate;
-
-    return date;
 };
 
 export const isDateValue = (

--- a/packages/my-components/src/DatePicker/DatePickerCalendar/DatePickerCalendar.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerCalendar/DatePickerCalendar.tsx
@@ -2,8 +2,11 @@ import React, { ComponentProps, useEffect } from 'react';
 
 import Calendar from '../../Calendar';
 import { useDatePicker } from '../DatePicker.context';
-import { getCalendarValue, getNextDate } from './DatePickerCalendar.utils';
 import styles from './DatePickerCalendar.module.scss';
+import {
+    getCalendarValue,
+    updateCalendarDate,
+} from './DatePickerCalendar.utils';
 
 const DatePickerCalendar = ({
     maxDate,
@@ -13,9 +16,9 @@ const DatePickerCalendar = ({
     const { date, handleChange, locale, initializeRange } = useDatePicker();
 
     const handleClickDay = (selectedDate: Date) => {
-        const nextDate = getNextDate(date, selectedDate);
+        const updatedDate = updateCalendarDate(date, selectedDate);
 
-        handleChange(nextDate);
+        handleChange(updatedDate);
     };
 
     useEffect(() => {

--- a/packages/my-components/src/DatePicker/DatePickerCalendar/DatePickerCalendar.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerCalendar/DatePickerCalendar.tsx
@@ -1,33 +1,36 @@
 import React, { ComponentProps, useEffect } from 'react';
-import { LooseValue } from 'react-calendar/dist/cjs/shared/types';
 
 import Calendar from '../../Calendar';
 import { useDatePicker } from '../DatePicker.context';
+import { getCalendarValue, getNextDate } from './DatePickerCalendar.utils';
 import styles from './DatePickerCalendar.module.scss';
-import { ModeDate } from './DatePickerCalendar.types';
 
 const DatePickerCalendar = ({
     maxDate,
     minDate,
     ...props
 }: ComponentProps<typeof Calendar>) => {
-    const { date, handleChange, mode, locale, initializeRange } =
-        useDatePicker();
+    const { date, handleChange, locale, initializeRange } = useDatePicker();
+
+    const handleClickDay = (selectedDate: Date) => {
+        const nextDate = getNextDate(date, selectedDate);
+
+        handleChange(nextDate);
+    };
 
     useEffect(() => {
-        initializeRange({ maxDate, minDate });
+        initializeRange({ maxDate: maxDate || null, minDate: minDate || null });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     return (
         <Calendar
-            value={date as LooseValue} // 라이브러리 타입을 변형해서 쓰는 게 위험할 수 있다.
+            value={getCalendarValue(date)}
             allowPartialRange
-            onChange={(date) => handleChange(date as ModeDate<typeof mode>)}
+            onClickDay={handleClickDay}
             locale={locale}
             minDate={minDate}
             maxDate={maxDate}
-            selectRange={mode === 'range'}
             className={styles.calendar}
             {...props}
         />

--- a/packages/my-components/src/DatePicker/DatePickerCalendar/DatePickerCalendar.utils.ts
+++ b/packages/my-components/src/DatePicker/DatePickerCalendar/DatePickerCalendar.utils.ts
@@ -2,7 +2,7 @@ import { LooseValue } from 'react-calendar/dist/cjs/shared/types';
 import { DateType } from '../DatePicker.types';
 import { getSortedDates, isDateValue } from '../DatePicker.utils';
 
-export const getNextDate = (date: DateType, currentDate: Date) => {
+export const updateCalendarDate = (date: DateType, currentDate: Date) => {
     if (isDateValue(date)) return currentDate;
 
     const { from, to } = date;

--- a/packages/my-components/src/DatePicker/DatePickerCalendar/DatePickerCalendar.utils.ts
+++ b/packages/my-components/src/DatePicker/DatePickerCalendar/DatePickerCalendar.utils.ts
@@ -1,0 +1,24 @@
+import { LooseValue } from 'react-calendar/dist/cjs/shared/types';
+import { DateType } from '../DatePicker.types';
+import { getSortedDates, isDateValue } from '../DatePicker.utils';
+
+export const getNextDate = (date: DateType, currentDate: Date) => {
+    if (isDateValue(date)) return currentDate;
+
+    const { from, to } = date;
+
+    if (from && !to) return getSortedDates({ from, to: currentDate });
+    else if (!from && to) return getSortedDates({ from: currentDate, to });
+    else return getSortedDates({ from: currentDate, to: null });
+};
+
+export const getCalendarValue = (date: DateType): LooseValue => {
+    if (isDateValue(date)) return date;
+
+    const { from, to } = date;
+
+    if (from && !to) return from;
+    if (!from && to) return to;
+
+    return [date.from, date.to];
+};

--- a/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.tsx
@@ -4,7 +4,7 @@ import { clsx } from 'clsx';
 import IconBase from '../../Icon/IconBase';
 
 import styles from './DatePickerInput.module.scss';
-import { useDateInput } from './DatePickerInput.hooks';
+import useDateInput from './DatePickerInput.hooks';
 import { DatePickerInputProps } from './DatePickerInput.types';
 
 const DatePickerInput = ({

--- a/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.types.ts
+++ b/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.types.ts
@@ -1,9 +1,9 @@
 import { ComponentProps } from 'react';
 
 export type InputState = 'default' | 'invalid' | 'valid';
-export type InputType = 'start' | 'end';
+export type InputType = 'from' | 'to' | 'single';
 
-export type SingleProps = ComponentProps<'input'> & { target?: never };
+export type SingleProps = ComponentProps<'input'> & { target: never };
 export type RangeProps = ComponentProps<'input'> & {
     target: InputType;
 };

--- a/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.types.ts
+++ b/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.types.ts
@@ -1,4 +1,5 @@
 import { ComponentProps } from 'react';
+import { DateType, DateValue, InitializeRangeProps } from '../DatePicker.types';
 
 export type InputState = 'default' | 'invalid' | 'valid';
 export type InputType = 'from' | 'to' | 'single';
@@ -15,14 +16,14 @@ export type DateInput = {
     state: InputState;
 };
 
-type SingleInputsProps = {
-    type: 'single';
-    placeholder: string;
-};
-type RangeInputsProps = {
-    type: 'range';
-    startPlaceholder: string;
-    endPlaceholder: string;
-};
+export type ConstrainDateToRangeProps = {
+    value: string;
+} & InitializeRangeProps;
 
-export type DatePickerInputsProps = SingleInputsProps | RangeInputsProps;
+export type IsDateFormatProps = { y: string; m: string; d: string };
+
+export type UpdateInputDate = {
+    date: DateType;
+    nextDate: DateValue;
+    target: InputType;
+};

--- a/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.utils.ts
+++ b/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.utils.ts
@@ -1,0 +1,26 @@
+import { DateType, DateValue, RangeDateValue } from '../DatePicker.types';
+import { getSortedDates, isDateValue } from '../DatePicker.utils';
+import { InputType } from './DatePickerInput.types';
+
+export const getTargetDate = (date: DateType, target: InputType): DateValue => {
+    if (!date || target === 'single') return date as DateValue;
+    else if ('from' in date && 'to' in date) return date[target];
+
+    return date;
+};
+
+export const getNextDate = (
+    currentDate: DateType,
+    nextDate: Date,
+    target: InputType,
+) => {
+    if (isDateValue(currentDate) || target === 'single') {
+        return nextDate;
+    } else {
+        const copiedDate = { ...currentDate } satisfies RangeDateValue;
+        copiedDate[target] = nextDate;
+
+        const sortedNextDate = getSortedDates(copiedDate);
+        return sortedNextDate;
+    }
+};

--- a/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.utils.ts
+++ b/packages/my-components/src/DatePicker/DatePickerInput/DatePickerInput.utils.ts
@@ -1,26 +1,75 @@
-import { DateType, DateValue, RangeDateValue } from '../DatePicker.types';
-import { getSortedDates, isDateValue } from '../DatePicker.utils';
-import { InputType } from './DatePickerInput.types';
+import {
+    DateType,
+    DateValue,
+    Locale,
+    RangeDateValue,
+} from '../DatePicker.types';
+import { isDateValue } from '../DatePicker.utils';
+import {
+    ConstrainDateToRangeProps,
+    InputType,
+    IsDateFormatProps,
+    UpdateInputDate,
+} from './DatePickerInput.types';
 
-export const getTargetDate = (date: DateType, target: InputType): DateValue => {
+export const getUpdatedDate = (
+    date: DateType,
+    target: InputType,
+): DateValue => {
     if (!date || target === 'single') return date as DateValue;
     else if ('from' in date && 'to' in date) return date[target];
 
     return date;
 };
 
-export const getNextDate = (
-    currentDate: DateType,
-    nextDate: Date,
-    target: InputType,
-) => {
+export const updateInputDate = ({
+    date: currentDate,
+    nextDate,
+    target,
+}: UpdateInputDate) => {
     if (isDateValue(currentDate) || target === 'single') {
         return nextDate;
     } else {
         const copiedDate = { ...currentDate } satisfies RangeDateValue;
         copiedDate[target] = nextDate;
 
-        const sortedNextDate = getSortedDates(copiedDate);
-        return sortedNextDate;
+        return copiedDate;
     }
+};
+
+export const constrainDateToRange = ({
+    value,
+    minDate,
+    maxDate,
+}: ConstrainDateToRangeProps) => {
+    const date = new Date(value);
+
+    if (minDate && date < minDate) return minDate;
+    if (maxDate && date > maxDate) return maxDate;
+
+    return date;
+};
+
+export const isDateFormat = ({ y, m, d }: IsDateFormatProps) => {
+    const date = new Date(`${y}-${m}-${d}`);
+
+    if (!date.getTime()) return false;
+    else return true;
+};
+
+export const getYMD = (value: string, locale: Locale) => {
+    const dates = value.replace(/[./]/g, ' ').split(' ');
+    let y, m, d;
+
+    if (locale === 'ko') {
+        [y, m, d] = dates;
+    } else {
+        [m, d, y] = dates;
+    }
+
+    return { y, m, d };
+};
+
+export const isValidDate = (value: string, locale: Locale) => {
+    return isDateFormat(getYMD(value, locale));
 };

--- a/packages/my-components/src/DatePicker/DatePickerTrigger/DatePickerTrigger.utils.ts
+++ b/packages/my-components/src/DatePicker/DatePickerTrigger/DatePickerTrigger.utils.ts
@@ -14,9 +14,9 @@ const getSingleInputText = (date: DateValue, locale: Locale) => {
 };
 
 const getRangeInputText = (date: RangeDateValue, locale: Locale) => {
-    const [start, end] = date;
-    const startValue = dateFormat(start, locale);
-    const endValue = dateFormat(end, locale);
+    const { from, to } = date;
+    const startValue = dateFormat(from, locale);
+    const endValue = dateFormat(to, locale);
 
     if (startValue && endValue) return `${startValue} - ${endValue}`;
     else return `${startValue || endValue}`;

--- a/packages/my-docs/stories/DatePicker.stories.tsx
+++ b/packages/my-docs/stories/DatePicker.stories.tsx
@@ -2,7 +2,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 import React, { ReactNode, useState } from 'react';
 
-import DatePicker, { DateType } from '../../my-components/src/DatePicker';
+import DatePicker, { RangeDateValue } from '../../my-components/src/DatePicker';
 import Button from '../../my-components/src/Button';
 import Stack from '../../my-components/src/Stack';
 
@@ -19,8 +19,6 @@ type Story = StoryObj<typeof DatePicker>;
 
 export const Default: Story = {
     render: () => {
-        // const [date, setDate] = useState<DateType>();
-
         return (
             <div style={{ width: '500px', height: '100dvh' }}>
                 <DatePicker locale="ko">
@@ -33,7 +31,10 @@ export const Default: Story = {
                                     '0.0625rem solid var(--border-color, rgb(225, 225, 232))',
                             }}
                         >
-                            <DatePicker.Input placeholder="날짜를 선택해주세요." />
+                            <DatePicker.Input
+                                target="single"
+                                placeholder="날짜를 선택해주세요."
+                            />
                         </div>
                         <DatePicker.Calendar
                             minDate={new Date('2024-07.05')}
@@ -61,14 +62,14 @@ export const Default: Story = {
 
 export const WithSidebar: Story = {
     render: () => {
-        const [date, setDate] = useState<DateType>();
+        const [date, setDate] = useState<RangeDateValue>();
         const handleRangeDate = (range: 'month' | 'week' | 'today') => {
             const date = new Date();
 
             if (range === 'month') date.setMonth(date.getMonth() - 1);
             else if (range === 'week') date.setDate(date.getDate() - 7);
 
-            setDate([date, new Date()]);
+            setDate({ from: date, to: new Date() });
         };
 
         return (
@@ -91,8 +92,8 @@ export const WithSidebar: Story = {
                                     '0.0625rem solid var(--border-color, rgb(225, 225, 232))',
                             }}
                         >
-                            <DatePicker.Input target="start" />
-                            <DatePicker.Input target="end" />
+                            <DatePicker.Input target="from" />
+                            <DatePicker.Input target="to" />
                         </div>
                         <div style={{ display: 'flex' }}>
                             <Stack
@@ -142,9 +143,8 @@ export const WithSidebar: Story = {
                     <span>date 상태: </span>
                     <br />
                     <br />
-                    {Array.isArray(date)
-                        ? `${date[0]?.toLocaleDateString()} ~ ${date[1]?.toLocaleDateString()}`
-                        : date?.toString()}
+                    {date?.from?.toLocaleDateString()} ~{' '}
+                    {date?.to?.toLocaleDateString()}
                 </div>
             </div>
         );
@@ -184,6 +184,3 @@ const RangeButton = ({
         </button>
     );
 };
-
-// range button, reset button 통일
-// 아예 사용자가 관리하거나, 아니면 형태 없이 기능만 관리하거나


### PR DESCRIPTION
> 아래 섹션들은 모두 선택사항입니다. 필요에 따라, 작성하지 않은 섹션은 지워주세요.

## 📝 변경 사항 요약
> 간략하게 변경 사항을 요약해주세요.

- Date의 타입을 객체 타입으로 관리하고, react-calendar의 동작으로 인한 버그를 onClickDay 프로퍼티 이용으로 해결합니다.


## 🛠 변경 사항 상세 설명
- Range 모드에서 date의 타입이 더이상 튜플이 아니라 `{ from: DateValue, to: DateValue }`로 유지됩니다.
- 변경된 타입에 맞게 각종 유틸 함수나 타입의 위치를 조정합니다.
- react calendar의 onChange 대신 onClickDay를사용하여 예상치 못한 동작을 수정합니다.
  - 날짜를 하나만 클릭한 후 해당 날짜 취소한 뒤 다시 날짜를 클릭하면 취소했던 날짜가 표기되는 버그가 있었습니다.
  - 이를 수정했습니다.
- 이제 range 모드에서 날짜 클릭 시 로직은 다음과 같습니다.
  1. `from`과 `to`가 모두 null일 때: 날짜 클릭 시 항상 `from`에 채워집니다.
  2. `from`이 선택되어 있고, `to`가 null일 때: 날짜 클릭 시 항상 `to`에 채워집니다.
  3. `from`이 null이고, `to`가 선택되어 있을 때: 날짜 클릭 시 항상 `from`에 채워집니다.
  4. `from`과 `to`가 모두 선택되어 있을 때: 날짜 클릭 시 항상 `from`에 채워지고 `to`는 null이 됩니다.