### PR TITLE
refactor(DatePicker): controllable state hooks 추가

### DIFF
--- a/packages/my-components/package.json
+++ b/packages/my-components/package.json
@@ -35,6 +35,7 @@
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-popover": "^1.1.1",
         "@radix-ui/react-slot": "^1.1.0",
+        "@radix-ui/react-use-controllable-state": "^1.1.0",
         "@types/lodash.once": "^4.1.9",
         "clsx": "^2.1.1",
         "lodash.once": "^4.1.1",

--- a/packages/my-components/src/DatePicker/DatePicker.constants.ts
+++ b/packages/my-components/src/DatePicker/DatePicker.constants.ts
@@ -3,3 +3,9 @@ export const LOCALES = {
     ja: 'ja-JP',
     en: 'en-US',
 } as const;
+
+export const RESET = {
+    ko: '초기화',
+    ja: 'リセット',
+    en: 'reset',
+};

--- a/packages/my-components/src/DatePicker/DatePicker.context.tsx
+++ b/packages/my-components/src/DatePicker/DatePicker.context.tsx
@@ -17,7 +17,7 @@ const createDatePickerContext = once(<T extends DateType>() =>
 const DatePickerProvider = <T extends DateType>({
     date: propDate,
     defaultDate,
-    onChangeDate,
+    onDateChange: onChangeDate,
     mode = 'single',
     locale = 'ko',
     children,

--- a/packages/my-components/src/DatePicker/DatePicker.context.tsx
+++ b/packages/my-components/src/DatePicker/DatePicker.context.tsx
@@ -9,7 +9,6 @@ import {
 import once from 'lodash.once';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { isDateValue } from './DatePicker.utils';
-// import { isDateValue } from './DatePicker.utils';
 
 const createDatePickerContext = once(<T extends DateType>() =>
     createContext<DatePickerContextType<T>>({} as DatePickerContextType<T>),

--- a/packages/my-components/src/DatePicker/DatePicker.context.tsx
+++ b/packages/my-components/src/DatePicker/DatePicker.context.tsx
@@ -7,29 +7,35 @@ import {
     InitializeRangeProps,
 } from './DatePicker.types';
 import once from 'lodash.once';
+import { useControllableState } from '@radix-ui/react-use-controllable-state';
+import { isDateValue } from './DatePicker.utils';
+// import { isDateValue } from './DatePicker.utils';
 
 const createDatePickerContext = once(<T extends DateType>() =>
     createContext<DatePickerContextType<T>>({} as DatePickerContextType<T>),
 );
 
 const DatePickerProvider = <T extends DateType>({
-    date,
+    date: propDate,
+    defaultDate,
     onChangeDate,
-    mode,
+    mode = 'single',
     locale = 'ko',
     children,
 }: DatePickerProviderProps<T>) => {
     const DatePickerContext = createDatePickerContext<T>();
-    const [innerDate, setInnerDate] = useState<T>(date as T);
-    const [defaultDate, setDefaultDate] = useState<T>(date as T);
+    const [date = null as T, setDate] = useControllableState<T>({
+        prop: propDate,
+        defaultProp: defaultDate,
+        onChange: onChangeDate,
+    });
     const [range, setRange] = useState<InitializeRangeProps>({
         minDate: new Date('1970.01.01'),
         maxDate: new Date('2999.12.31'),
     });
 
     const handleChange = (nextDate: T) => {
-        setInnerDate(nextDate);
-        onChangeDate?.(nextDate);
+        setDate(nextDate);
     };
 
     const initializeRange = ({ minDate, maxDate }: InitializeRangeProps) => {
@@ -38,16 +44,18 @@ const DatePickerProvider = <T extends DateType>({
     };
 
     useEffect(() => {
-        if (mode === 'range' && date === undefined) {
-            const initialDate = { from: null, to: null };
-            handleChange(initialDate as T);
-            setDefaultDate(initialDate as T);
+        if (mode === 'single') return;
 
-            return;
+        const initDate = date || defaultDate || null;
+
+        if (isDateValue(initDate)) {
+            const initialRangeDate = {
+                from: initDate,
+                to: initDate,
+            } as T;
+
+            handleChange(initialRangeDate);
         }
-
-        setInnerDate(date as T);
-        setDefaultDate(date as T);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -55,7 +63,7 @@ const DatePickerProvider = <T extends DateType>({
         <DatePickerContext.Provider
             value={{
                 ...range,
-                date: innerDate,
+                date,
                 defaultDate,
                 initializeRange,
                 handleChange,

--- a/packages/my-components/src/DatePicker/DatePicker.types.ts
+++ b/packages/my-components/src/DatePicker/DatePicker.types.ts
@@ -20,7 +20,7 @@ export type InitializeRangeProps = {
 
 export type DatePickerContextType<T extends DateType> = {
     date: T;
-    defaultDate: T;
+    defaultDate?: T;
     handleChange: (date: T) => void;
     initializeRange: (range: InitializeRangeProps) => void;
     mode?: Mode;
@@ -31,6 +31,7 @@ export type DatePickerProviderProps<T> = {
     mode?: Mode;
     locale?: Locale;
     date?: T;
+    defaultDate?: T;
     onChangeDate?: (date: T) => void;
     children: ReactNode;
 };

--- a/packages/my-components/src/DatePicker/DatePicker.types.ts
+++ b/packages/my-components/src/DatePicker/DatePicker.types.ts
@@ -32,7 +32,7 @@ export type DatePickerProviderProps<T> = {
     locale?: Locale;
     date?: T;
     defaultDate?: T;
-    onChangeDate?: (date: T) => void;
+    onDateChange?: (date: T) => void;
     children: ReactNode;
 };
 

--- a/packages/my-components/src/DatePicker/DatePickerReset/DatePickerReset.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerReset/DatePickerReset.tsx
@@ -6,20 +6,27 @@ import { useDatePicker } from '../DatePicker.context';
 import IconBase from '../../Icon/IconBase';
 import styles from './DatePickerReset.module.scss';
 import { DatePickerResetProps } from './DatePickerReset.types';
+import { RESET } from '../DatePicker.constants';
+import { isDateValue } from '../DatePicker.utils';
 
 const DatePickerReset = ({
     asChild = false,
     children,
     ...props
 }: DatePickerResetProps) => {
-    const { handleChange, defaultDate = null } = useDatePicker();
-    const reset = () => handleChange(defaultDate);
+    const { mode, handleChange, defaultDate = null, locale } = useDatePicker();
+    const reset = () => {
+        if (mode === 'single') return handleChange(defaultDate);
+        if (!isDateValue(defaultDate)) return handleChange(defaultDate);
+
+        handleChange({ from: defaultDate, to: defaultDate });
+    };
 
     const Comp = asChild ? Slot : 'button';
     const customReset = (
         <>
             <RefreshIcon />
-            {children || '초기화'}
+            {children || RESET[locale]}
         </>
     );
 

--- a/packages/my-components/src/DatePicker/DatePickerReset/DatePickerReset.tsx
+++ b/packages/my-components/src/DatePicker/DatePickerReset/DatePickerReset.tsx
@@ -12,7 +12,7 @@ const DatePickerReset = ({
     children,
     ...props
 }: DatePickerResetProps) => {
-    const { handleChange, defaultDate } = useDatePicker();
+    const { handleChange, defaultDate = null } = useDatePicker();
     const reset = () => handleChange(defaultDate);
 
     const Comp = asChild ? Slot : 'button';

--- a/packages/my-docs/stories/DatePicker.stories.tsx
+++ b/packages/my-docs/stories/DatePicker.stories.tsx
@@ -5,6 +5,7 @@ import React, { ReactNode, useState } from 'react';
 import DatePicker, { RangeDateValue } from '../../my-components/src/DatePicker';
 import Button from '../../my-components/src/Button';
 import Stack from '../../my-components/src/Stack';
+import { argTypes } from './utils';
 
 const meta: Meta<typeof DatePicker> = {
     title: 'DatePicker',
@@ -12,16 +13,27 @@ const meta: Meta<typeof DatePicker> = {
         layout: 'centered',
     },
     tags: ['autodocs'],
+    argTypes: {
+        open: argTypes({ control: 'boolean' }),
+        modal: argTypes({ control: 'boolean' }),
+        locale: argTypes({
+            control: 'inline-radio',
+            options: ['ko', 'ja', 'en'],
+        }),
+    },
+    args: {
+        locale: 'ko',
+    },
 };
 
 export default meta;
 type Story = StoryObj<typeof DatePicker>;
 
 export const Default: Story = {
-    render: () => {
+    render: (args) => {
         return (
             <div style={{ width: '500px', height: '100dvh' }}>
-                <DatePicker locale="ko">
+                <DatePicker {...args} defaultDate={new Date('1998.5.19')}>
                     <DatePicker.Trigger />
                     <DatePicker.Content>
                         <div
@@ -61,7 +73,7 @@ export const Default: Story = {
 };
 
 export const WithSidebar: Story = {
-    render: () => {
+    render: (args) => {
         const [date, setDate] = useState<RangeDateValue>();
         const handleRangeDate = (range: 'month' | 'week' | 'today') => {
             const date = new Date();
@@ -77,8 +89,10 @@ export const WithSidebar: Story = {
                 <DatePicker
                     date={date}
                     onChangeDate={(date) => setDate(date)}
-                    locale="ko"
                     mode="range"
+                    locale={args.locale}
+                    modal={args.modal}
+                    open={args.open}
                 >
                     <DatePicker.Trigger />
                     <DatePicker.Content>


### PR DESCRIPTION
> 아래 섹션들은 모두 선택사항입니다. 필요에 따라, 작성하지 않은 섹션은 지워주세요.

## 📝 변경 사항 요약
> 간략하게 변경 사항을 요약해주세요.

- use-controllable-state 훅으로 controllable, uncontrollable 관리의 편의성 추가


## 🛠 변경 사항 상세 설명
- propState, onChangePropState, defaultProp을 추가하면 내부에서 state와 이를 변경할 수 있는 함수를 전달합니다.
- 따라서 별다른 처리 없이 control, uncontrol state에 대한 관리를 할 수 있습니다.
- reset button에 대한 locale 추가
- storybook arguments 추가